### PR TITLE
Add codecov coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: node_js
 
 node_js:
   - 10
+
+after_script:
+  - ./node_modules/.bin/codecov

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
     "babel-plugin-source-map-support": "^2.0.1",
-    "codecov": "^3.0.0",
+    "codecov": "^3.2.0",
     "eslint": "^4.7.2",
     "eslint-plugin-import": "^2.8.0",
     "jest": "^24.1.0",


### PR DESCRIPTION
Let's add a code coverage report on codecov so we have an overview about the code coverage of this project. Everything is already set up on https://codecov.io/gh/saucelabs/speedo