### PR TITLE
optimize Docker context size by ignoring unnecessary dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+.git
 node_modules
 build
 coverage
+docs
+tests


### PR DESCRIPTION
We don't need a few directories that otherwise bloat the Docker context size.

```
# BEFORE
$ docker build -t quay.io/saucelabs/speedo .
Sending build context to Docker daemon  540.7kB

# AFTER
$ docker build -t quay.io/saucelabs/speedo .
Sending build context to Docker daemon     64kB
```

Not an impactful difference yet but it will prevent from growing in the future.