### PR TITLE
Add parentTunnel parameter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -87,6 +87,9 @@ export const RUN_CLI_PARAMS ={
     tunnelIdentifier: {
         alias: 'i',
         description: 'identifier for Sauce Connect tunnel to run performance tests for local hosted apps'
+    },
+    parentTunnel: {
+        description: 'username of parent running Sauce Connect tunnel'
     }
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -3,11 +3,12 @@ import { remote } from 'webdriverio'
 import { getMetricParams } from './utils'
 
 export default async function runPerformanceTest (username, accessKey, argv, name, build, logDir) {
-    const { site, platformName: platform, browserVersion: version, tunnelIdentifier } = argv
+    const { site, platformName: platform, browserVersion: version, tunnelIdentifier, parentTunnel } = argv
     const metrics = getMetricParams(argv)
     const sauceOptions = {
         name, build, extendedDebugging: true, capturePerformance: true,
-        ...(tunnelIdentifier ? { tunnelIdentifier } : {})
+        ...(tunnelIdentifier ? { tunnelIdentifier } : {}),
+        ...(parentTunnel ? { parentTunnel } : {})
     }
 
     const browser = await remote({

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -40,6 +40,66 @@ Array [
 ]
 `;
 
+exports[`runPerformanceTest w/ parentTunnel 1`] = `
+Object {
+  "result": Object {
+    "value": Object {
+      "metrics": Object {
+        "load": 321,
+        "pageWeight": 1000,
+        "speedIndex": 10,
+        "timeToFirstByte": 123,
+      },
+    },
+  },
+  "sessionId": "foobarSession",
+}
+`;
+
+exports[`runPerformanceTest w/ parentTunnel 2`] = `
+Array [
+  Array [
+    Object {
+      "capabilities": Object {
+        "browserName": "chrome",
+        "build": "buildname",
+        "capturePerformance": true,
+        "extendedDebugging": true,
+        "name": "testname",
+        "platform": "Playstation",
+        "tunnelIdentifier": "foobar",
+        "version": 123,
+      },
+      "key": "mykey",
+      "logLevel": "trace",
+      "outputDir": "/some/dir",
+      "region": "eu",
+      "user": "myuser",
+    },
+  ],
+  Array [
+    Object {
+      "capabilities": Object {
+        "browserName": "chrome",
+        "build": "buildname",
+        "capturePerformance": true,
+        "extendedDebugging": true,
+        "name": "testname",
+        "parentTunnel": "foobaz",
+        "platform": "Playstation",
+        "tunnelIdentifier": "foobar",
+        "version": 123,
+      },
+      "key": "mykey",
+      "logLevel": "trace",
+      "outputDir": "/some/dir",
+      "region": "eu",
+      "user": "myuser",
+    },
+  ],
+]
+`;
+
 exports[`runPerformanceTest without args 1`] = `
 Object {
   "result": Object {
@@ -66,6 +126,26 @@ Array [
         "capturePerformance": true,
         "extendedDebugging": true,
         "name": "testname",
+        "platform": "Playstation",
+        "tunnelIdentifier": "foobar",
+        "version": 123,
+      },
+      "key": "mykey",
+      "logLevel": "trace",
+      "outputDir": "/some/dir",
+      "region": "eu",
+      "user": "myuser",
+    },
+  ],
+  Array [
+    Object {
+      "capabilities": Object {
+        "browserName": "chrome",
+        "build": "buildname",
+        "capturePerformance": true,
+        "extendedDebugging": true,
+        "name": "testname",
+        "parentTunnel": "foobaz",
         "platform": "Playstation",
         "tunnelIdentifier": "foobar",
         "version": 123,

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -20,6 +20,25 @@ test('runPerformanceTest', async () => {
     expect(remote.mock.calls).toMatchSnapshot()
 })
 
+test('runPerformanceTest w/ parentTunnel', async () => {
+    const result = await runPerformanceTest(
+        'myuser',
+        'mykey',
+        {
+            region: 'eu',
+            platformName: 'Playstation',
+            browserVersion: 123,
+            tunnelIdentifier: 'foobar',
+            parentTunnel: 'foobaz'
+        },
+        'testname',
+        'buildname',
+        '/some/dir'
+    )
+    expect(result).toMatchSnapshot()
+    expect(remote.mock.calls).toMatchSnapshot()
+})
+
 test('runPerformanceTest without args', async () => {
     const result = await runPerformanceTest(
         'myuser',


### PR DESCRIPTION
Enables users that are using a shared tunnel to run performance tests.