### PR TITLE
Filter metrics for baseline requests

### DIFF
--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -4,7 +4,7 @@ import SauceLabs from 'saucelabs'
 
 import { getMetricParams, getJobUrl, analyzeReport, waitFor } from '../utils'
 import {
-    ERROR_MISSING_CREDENTIALS, ANALYZE_CLI_PARAMS, PERFORMANCE_METRICS
+    ERROR_MISSING_CREDENTIALS, ANALYZE_CLI_PARAMS, BASELINE_METRICS
 } from '../constants'
 
 export const command = 'analyze [params...] <jobName>'
@@ -95,7 +95,7 @@ export const handler = async (argv) => {
         for (const pageLoadMetric of performanceMetrics.items) {
             const results = {}
             const baselineHistory = await user.getBaselineHistory(job.id, {
-                metricNames: PERFORMANCE_METRICS,
+                metricNames: BASELINE_METRICS,
                 orderIndex: pageLoadMetric.order_index
             })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,8 +13,16 @@ export const PERFORMANCE_METRICS = [
     'load',
     'speedIndex',
     'perceptualSpeedIndex',
+    'pageWeight',
     'pageWeightEncoded'
 ]
+
+export const PERFORMANCE_IGNORED_METRICS = [
+    'pageWeight',
+    'requestsCount'
+]
+
+export const BASELINE_METRICS = PERFORMANCE_METRICS.filter((metric) => !PERFORMANCE_IGNORED_METRICS.includes(metric))
 
 const METRIC_PARAM = {
     alias: 'm',

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,6 @@ export const PERFORMANCE_METRICS = [
     'load',
     'speedIndex',
     'perceptualSpeedIndex',
-    'pageWeight',
     'pageWeightEncoded'
 ]
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,8 @@ export const PERFORMANCE_METRICS = [
     'pageWeightEncoded'
 ]
 
+// Following metrics are fairly stable and as result baselines are super narrow
+// so whenever a regression happens users get notified of things that they don't really care
 export const PERFORMANCE_IGNORED_METRICS = [
     'pageWeight',
     'requestsCount'

--- a/tests/__fixtures__/performance.js
+++ b/tests/__fixtures__/performance.js
@@ -275,18 +275,6 @@ export const BASELINE_HISTORY = {
             job_id: '83d526a5d20040a7b854a2cbef64c067'
         }
     ],
-    pageWeight: [
-        {
-            b: 2945120,
-            u: 2945120,
-            l: 2945120,
-            r: 2945120,
-            datetime: '2019-03-17T17:36:22Z',
-            new_regime: 0,
-            accepted: 0,
-            job_id: '83d526a5d20040a7b854a2cbef64c067'
-        }
-    ],
     pageWeightEncoded: [
         {
             b: 1652947,

--- a/tests/__fixtures__/performance.json
+++ b/tests/__fixtures__/performance.json
@@ -143,21 +143,6 @@
                         "job_id": "83d526a5d20040a7b854a2cbef64c067"
                     }
                 },
-                "pageWeight": {
-                    "metric": "pageWeight",
-                    "passed": true,
-                    "value": 4102578,
-                    "baseline": {
-                        "b": 4102578,
-                        "u": 4102578,
-                        "l": 4102578,
-                        "r": 4102578,
-                        "datetime": "2019-03-17T17:36:22Z",
-                        "new_regime": 0,
-                        "accepted": 0,
-                        "job_id": "83d526a5d20040a7b854a2cbef64c067"
-                    }
-                },
                 "pageWeightEncoded": {
                     "metric": "pageWeightEncoded",
                     "passed": true,
@@ -309,21 +294,6 @@
                         "u": 2170.7188092909014,
                         "l": 2170.7188092909014,
                         "r": 2170.7188092909014,
-                        "datetime": "2019-03-17T17:36:22Z",
-                        "new_regime": 0,
-                        "accepted": 0,
-                        "job_id": "83d526a5d20040a7b854a2cbef64c067"
-                    }
-                },
-                "pageWeight": {
-                    "metric": "pageWeight",
-                    "passed": true,
-                    "value": 5233683,
-                    "baseline": {
-                        "b": 5233683,
-                        "u": 5233683,
-                        "l": 5233683,
-                        "r": 5233683,
                         "datetime": "2019-03-17T17:36:22Z",
                         "new_regime": 0,
                         "accepted": 0,

--- a/tests/__snapshots__/analyze.test.js.snap
+++ b/tests/__snapshots__/analyze.test.js.snap
@@ -85,21 +85,6 @@ Array [
               "passed": true,
               "value": 9021.5,
             },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
-            },
             "pageWeightEncoded": Object {
               "baseline": Object {
                 "accepted": 0,
@@ -269,21 +254,6 @@ Array [
             "passed": true,
             "value": 9021.5,
           },
-          "pageWeight": Object {
-            "baseline": Object {
-              "accepted": 0,
-              "b": 2945120,
-              "datetime": "2019-03-17T17:36:22Z",
-              "job_id": "83d526a5d20040a7b854a2cbef64c067",
-              "l": 2945120,
-              "new_regime": 0,
-              "r": 2945120,
-              "u": 2945120,
-            },
-            "metric": "pageWeight",
-            "passed": true,
-            "value": 2945120,
-          },
           "pageWeightEncoded": Object {
             "baseline": Object {
               "accepted": 0,
@@ -441,21 +411,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {
@@ -626,21 +581,6 @@ Array [
             "passed": true,
             "value": 9021.5,
           },
-          "pageWeight": Object {
-            "baseline": Object {
-              "accepted": 0,
-              "b": 2945120,
-              "datetime": "2019-03-17T17:36:22Z",
-              "job_id": "83d526a5d20040a7b854a2cbef64c067",
-              "l": 2945120,
-              "new_regime": 0,
-              "r": 2945120,
-              "u": 2945120,
-            },
-            "metric": "pageWeight",
-            "passed": true,
-            "value": 2945120,
-          },
           "pageWeightEncoded": Object {
             "baseline": Object {
               "accepted": 0,
@@ -798,21 +738,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {
@@ -990,21 +915,6 @@ Array [
               "passed": true,
               "value": 9021.5,
             },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
-            },
             "pageWeightEncoded": Object {
               "baseline": Object {
                 "accepted": 0,
@@ -1174,21 +1084,6 @@ Array [
             "passed": true,
             "value": 9021.5,
           },
-          "pageWeight": Object {
-            "baseline": Object {
-              "accepted": 0,
-              "b": 2945120,
-              "datetime": "2019-03-17T17:36:22Z",
-              "job_id": "83d526a5d20040a7b854a2cbef64c067",
-              "l": 2945120,
-              "new_regime": 0,
-              "r": 2945120,
-              "u": 2945120,
-            },
-            "metric": "pageWeight",
-            "passed": true,
-            "value": 2945120,
-          },
           "pageWeightEncoded": Object {
             "baseline": Object {
               "accepted": 0,
@@ -1346,21 +1241,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {
@@ -1531,21 +1411,6 @@ Array [
             "passed": true,
             "value": 9021.5,
           },
-          "pageWeight": Object {
-            "baseline": Object {
-              "accepted": 0,
-              "b": 2945120,
-              "datetime": "2019-03-17T17:36:22Z",
-              "job_id": "83d526a5d20040a7b854a2cbef64c067",
-              "l": 2945120,
-              "new_regime": 0,
-              "r": 2945120,
-              "u": 2945120,
-            },
-            "metric": "pageWeight",
-            "passed": true,
-            "value": 2945120,
-          },
           "pageWeightEncoded": Object {
             "baseline": Object {
               "accepted": 0,
@@ -1703,21 +1568,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {
@@ -1889,21 +1739,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {
@@ -2091,21 +1926,6 @@ Array [
               "metric": "load",
               "passed": true,
               "value": 9021.5,
-            },
-            "pageWeight": Object {
-              "baseline": Object {
-                "accepted": 0,
-                "b": 2945120,
-                "datetime": "2019-03-17T17:36:22Z",
-                "job_id": "83d526a5d20040a7b854a2cbef64c067",
-                "l": 2945120,
-                "new_regime": 0,
-                "r": 2945120,
-                "u": 2945120,
-              },
-              "metric": "pageWeight",
-              "passed": true,
-              "value": 2945120,
             },
             "pageWeightEncoded": Object {
               "baseline": Object {

--- a/tests/__snapshots__/utils.test.js.snap
+++ b/tests/__snapshots__/utils.test.js.snap
@@ -17,7 +17,6 @@ Performance Results
 ╟───┼─────────────────────────┼──────────────────────────────╢
 ║ 0 │ https://www.amazon.com/ │ load: 4.9s                   ║
 ║   │                         │ speedIndex: 2s               ║
-║   │                         │ pageWeight: 5.23 MB          ║
 ║   │                         │ timeToFirstByte: 693ms       ║
 ║   │                         │ firstPaint: 1.4s             ║
 ║   │                         │ firstContentfulPaint: 1.4s   ║
@@ -29,7 +28,6 @@ Performance Results
 ╟───┼─────────────────────────┼──────────────────────────────╢
 ║ 1 │ https://www.yahoo.com/  │ load: 9.8s                   ║
 ║   │                         │ speedIndex: 1.3s             ║
-║   │                         │ pageWeight: 4.1 MB           ║
 ║   │                         │ timeToFirstByte: 502ms       ║
 ║   │                         │ firstPaint: 1.2s             ║
 ║   │                         │ firstContentfulPaint: 1.7s   ║
@@ -69,9 +67,6 @@ Performance Results
     "firstMeaningfulPaint: 222ms",
   ],
   Array [
-    "pageWeight: 1 kB",
-  ],
-  Array [
     "
 Performance assertions failed! ❌
 Expected speedIndex to be between 3ms and 7ms but was actually 10ms
@@ -101,9 +96,6 @@ Performance Results
   ],
   Array [
     "firstMeaningfulPaint: 222ms",
-  ],
-  Array [
-    "pageWeight: 1 kB",
   ],
   Array [
     "

--- a/tests/__snapshots__/utils.test.js.snap
+++ b/tests/__snapshots__/utils.test.js.snap
@@ -67,6 +67,9 @@ Performance Results
     "firstMeaningfulPaint: 222ms",
   ],
   Array [
+    "pageWeight: 1 kB",
+  ],
+  Array [
     "
 Performance assertions failed! ❌
 Expected speedIndex to be between 3ms and 7ms but was actually 10ms
@@ -96,6 +99,9 @@ Performance Results
   ],
   Array [
     "firstMeaningfulPaint: 222ms",
+  ],
+  Array [
+    "pageWeight: 1 kB",
   ],
   Array [
     "


### PR DESCRIPTION
Ticket: PERF-710

Problem:
pageWeight and requestsCount metrics are very stable, so remove the ability to query them.

Solution:
Filter metrics for baseline request.