### PR TITLE
simplify logic for metrics/jobs pass/failing

### DIFF
--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -123,13 +123,13 @@ export const handler = async (argv) => {
             jobResult.results.push({
                 orderIndex: pageLoadMetric.order_index,
                 url:  pageLoadMetric.page_url,
-                passed: !Object.values(results).find((r) => !r.passed), // pass only if no failing metrics
+                passed: Object.values(results).every((r) => r.passed), // pass only if no failing metrics
                 metrics: results
             })
         }
 
         // pass only if no failing results
-        jobResult.passed = !Object.values(jobResult.results).find((r) => !r.passed)
+        jobResult.passed = Object.values(jobResult.results).every((r) => r.passed)
         status.succeed()
     } catch (e) {
         status.fail(`Couldn't fetch performance results: ${e.stack}`)


### PR DESCRIPTION
This was the minor change that didn't get added into https://github.com/saucelabs/speedo/pull/29 before it was merged.