### PR TITLE
Change link to job details page to performance details page

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -143,7 +143,7 @@ export const getThrottleCpuParam = function (argv) {
  */
 export const getJobUrl = function (argv, sessionId) {
     const hostname = (!argv.region || !argv.region.includes('eu') ? '' : 'eu-central-1.') + 'saucelabs.com'
-    return `https://app.${hostname}/performance/${sessionId}`
+    return `https://app.${hostname}/performance/${sessionId}/0`
 }
 
 export const formatMetric = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,7 +143,7 @@ export const getThrottleCpuParam = function (argv) {
  */
 export const getJobUrl = function (argv, sessionId) {
     const hostname = (!argv.region || !argv.region.includes('eu') ? '' : 'eu-central-1.') + 'saucelabs.com'
-    return `https://app.${hostname}/tests/${sessionId}`
+    return `https://app.${hostname}/performance/${sessionId}`
 }
 
 export const formatMetric = {

--- a/tests/__fixtures__/performance.json
+++ b/tests/__fixtures__/performance.json
@@ -1,7 +1,7 @@
 {
     "id": "83d526a5d20040a7b854a2cbef64c067",
     "name": "my performance test",
-    "url": "https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067",
+    "url": "https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067/0",
     "results": [
         {
             "orderIndex": 1,

--- a/tests/__fixtures__/performance.json
+++ b/tests/__fixtures__/performance.json
@@ -1,7 +1,7 @@
 {
     "id": "83d526a5d20040a7b854a2cbef64c067",
     "name": "my performance test",
-    "url": "https://app.saucelabs.com/tests/83d526a5d20040a7b854a2cbef64c067",
+    "url": "https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067",
     "results": [
         {
             "orderIndex": 1,

--- a/tests/__snapshots__/analyze.test.js.snap
+++ b/tests/__snapshots__/analyze.test.js.snap
@@ -166,7 +166,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -337,7 +337,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -508,7 +508,7 @@ Array [
           "url": "http://saucelabs-slow.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -684,7 +684,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -855,7 +855,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -1026,7 +1026,7 @@ Array [
           "url": "http://saucelabs-slow.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -1197,7 +1197,7 @@ Array [
           "url": "http://saucelabs-fast.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",
@@ -1384,7 +1384,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/performance/foobar",
+      "url": "https://saucelabs.com/performance/foobar/0",
     },
     Array [
       "speedIndex",

--- a/tests/__snapshots__/analyze.test.js.snap
+++ b/tests/__snapshots__/analyze.test.js.snap
@@ -166,7 +166,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -337,7 +337,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -508,7 +508,7 @@ Array [
           "url": "http://saucelabs-slow.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -684,7 +684,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -855,7 +855,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -1026,7 +1026,7 @@ Array [
           "url": "http://saucelabs-slow.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -1197,7 +1197,7 @@ Array [
           "url": "http://saucelabs-fast.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",
@@ -1384,7 +1384,7 @@ Array [
           "url": "http://saucelabs.com/",
         },
       ],
-      "url": "https://saucelabs.com/tests/foobar",
+      "url": "https://saucelabs.com/performance/foobar",
     },
     Array [
       "speedIndex",

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -29,7 +29,7 @@ Array [
   Array [
     Object {
       "symbol": "👀",
-      "text": "Check out job at https://saucelabs.com/tests/foobar",
+      "text": "Check out job at https://saucelabs.com/performance/foobar",
     },
   ],
 ]

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -29,7 +29,7 @@ Array [
   Array [
     Object {
       "symbol": "👀",
-      "text": "Check out job at https://saucelabs.com/performance/foobar",
+      "text": "Check out job at https://saucelabs.com/performance/foobar/0",
     },
   ],
 ]

--- a/tests/__snapshots__/utils.test.js.snap
+++ b/tests/__snapshots__/utils.test.js.snap
@@ -38,7 +38,7 @@ Performance Results
 ║   │                         │ pageWeightEncoded: 528 kB    ║
 ╚═══╧═════════════════════════╧══════════════════════════════╝
 ",
-    "👀 Check out job at https://app.saucelabs.com/tests/83d526a5d20040a7b854a2cbef64c067
+    "👀 Check out job at https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067
 ",
   ],
 ]

--- a/tests/__snapshots__/utils.test.js.snap
+++ b/tests/__snapshots__/utils.test.js.snap
@@ -38,7 +38,7 @@ Performance Results
 ║   │                         │ pageWeightEncoded: 528 kB    ║
 ╚═══╧═════════════════════════╧══════════════════════════════╝
 ",
-    "👀 Check out job at https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067
+    "👀 Check out job at https://app.saucelabs.com/performance/83d526a5d20040a7b854a2cbef64c067/0
 ",
   ],
 ]

--- a/tests/analyze.test.js
+++ b/tests/analyze.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
     delete process.env.SAUCE_ACCESS_KEY
 
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
-    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar')
+    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({ sessionId: 'foobar123', result: { result: 'pass' } }))
 })

--- a/tests/analyze.test.js
+++ b/tests/analyze.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
     delete process.env.SAUCE_ACCESS_KEY
 
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
-    getJobUrl.mockImplementation(() => 'https://saucelabs.com/tests/foobar')
+    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({ sessionId: 'foobar123', result: { result: 'pass' } }))
 })

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
     delete process.env.SAUCE_ACCESS_KEY
 
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
-    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar')
+    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({ sessionId: 'foobar123', result: { result: 'pass' } }))
 })

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
     delete process.env.SAUCE_ACCESS_KEY
 
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
-    getJobUrl.mockImplementation(() => 'https://saucelabs.com/tests/foobar')
+    getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({ sessionId: 'foobar123', result: { result: 'pass' } }))
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -109,11 +109,11 @@ test('getThrottleCpuParam', () => {
 
 test('getJobUrl', () => {
     expect(getJobUrl({}, 'foobar'))
-        .toEqual('https://app.saucelabs.com/tests/foobar')
+        .toEqual('https://app.saucelabs.com/performance/foobar')
     expect(getJobUrl({ region: 'eu' }, 'foobar'))
-        .toEqual('https://app.eu-central-1.saucelabs.com/tests/foobar')
+        .toEqual('https://app.eu-central-1.saucelabs.com/performance/foobar')
     expect(getJobUrl({ region: 'what?' }, 'foobar'))
-        .toEqual('https://app.saucelabs.com/tests/foobar')
+        .toEqual('https://app.saucelabs.com/performance/foobar')
 })
 
 test('analyzeReport', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -109,11 +109,11 @@ test('getThrottleCpuParam', () => {
 
 test('getJobUrl', () => {
     expect(getJobUrl({}, 'foobar'))
-        .toEqual('https://app.saucelabs.com/performance/foobar')
+        .toEqual('https://app.saucelabs.com/performance/foobar/0')
     expect(getJobUrl({ region: 'eu' }, 'foobar'))
-        .toEqual('https://app.eu-central-1.saucelabs.com/performance/foobar')
+        .toEqual('https://app.eu-central-1.saucelabs.com/performance/foobar/0')
     expect(getJobUrl({ region: 'what?' }, 'foobar'))
-        .toEqual('https://app.saucelabs.com/performance/foobar')
+        .toEqual('https://app.saucelabs.com/performance/foobar/0')
 })
 
 test('analyzeReport', () => {


### PR DESCRIPTION
With the introduction of the new job details UI we have a dedicated performance page that speedo should link to.