### PR TITLE
make user and key flags take precedence over environment variables

### DIFF
--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -12,8 +12,8 @@ export const desc = 'Analyze results of prerun performance tests.'
 export const builder = ANALYZE_CLI_PARAMS
 
 export const handler = async (argv) => {
-    const username = process.env.SAUCE_USERNAME || argv.user
-    const accessKey = process.env.SAUCE_ACCESS_KEY || argv.key
+    const username = argv.user || process.env.SAUCE_USERNAME
+    const accessKey = argv.key || process.env.SAUCE_ACCESS_KEY
     const metrics = getMetricParams(argv)
 
     /**

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -16,8 +16,8 @@ export const desc = 'Run performance tests on any website.'
 export const builder = RUN_CLI_PARAMS
 
 export const handler = async (argv) => {
-    const username = process.env.SAUCE_USERNAME || argv.user
-    const accessKey = process.env.SAUCE_ACCESS_KEY || argv.key
+    const username = argv.user || process.env.SAUCE_USERNAME
+    const accessKey = argv.key || process.env.SAUCE_ACCESS_KEY
     const jobName = argv.name || `Performance test for ${argv.site}`
     const buildName = argv.build || `${jobName} - ${(new Date()).toString()}`
     const metrics = getMetricParams(argv)


### PR DESCRIPTION
At the moment the only way to analyze or run tests as another user is to either change your SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables or to set them to null.

By reversing the order in which we read the keys, we allow for the user to enter the desired username and access key as a flag and fall back to environment variables if nothing is found.