### PR TITLE
Allow to disable CPU throttling

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,7 +10,7 @@ import changeCase from 'change-case'
 import runPerformanceTest from '../runner'
 import {
     printResult, waitFor, getMetricParams, getJobUrl,
-    getJobName, getThrottleNetworkParam, getThrottleCpuParam
+    getJobName, getThrottleNetworkParam
 } from '../utils'
 import { ERROR_MISSING_CREDENTIALS, REQUIRED_TESTS_FOR_BASELINE_COUNT, RUN_CLI_PARAMS } from '../constants'
 
@@ -202,10 +202,9 @@ export const handler = async (argv) => {
     printResult(result, performanceLog[0], metrics, argv)
 
     const networkCondition = getThrottleNetworkParam(argv)
-    const cpuRate = getThrottleCpuParam(argv)
     // eslint-disable-next-line no-console
     status.stopAndPersist({
-        text: `Runtime settings:\n- Network Throttling: ${networkCondition}\n- CPU Throttling: ${cpuRate}x\n`,
+        text: `Runtime settings:\n- Network Throttling: ${networkCondition}\n- CPU Throttling: ${argv.throttleCpu}x\n`,
         symbol: '⚙️ '
     })
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,6 +1,6 @@
 import { remote } from 'webdriverio'
 
-import { getMetricParams, getThrottleNetworkParam, getThrottleCpuParam } from './utils'
+import { getMetricParams, getThrottleNetworkParam } from './utils'
 
 const MAX_RETRIES = 3
 
@@ -19,7 +19,6 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
     const { site, platformName, browserVersion, tunnelIdentifier, parentTunnel } = argv
     const metrics = getMetricParams(argv)
     const networkCondition = getThrottleNetworkParam(argv)
-    const cpuRate = getThrottleCpuParam(argv)
     const sauceOptions = {
         'sauce:options': {
             name,
@@ -57,7 +56,7 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
     await browser.throttleNetwork(networkCondition)
     await browser.execute('sauce:debug', {
         method: 'Emulation.setCPUThrottlingRate',
-        params: { rate: cpuRate }
+        params: { rate: argv.throttleCpu }
     })
     await browser.url(site)
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -53,11 +53,26 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
 
     const sessionId = browser.sessionId
 
-    await browser.throttleNetwork(networkCondition)
-    await browser.execute('sauce:debug', {
-        method: 'Emulation.setCPUThrottlingRate',
-        params: { rate: argv.throttleCpu }
-    })
+    /**
+     * throttle network
+     */
+    if (networkCondition !== 'online') {
+        await browser.throttleNetwork(networkCondition)
+    }
+
+    /**
+     * throttle CPU
+     */
+    if (argv.throttleCpu !== 0) {
+        await browser.execute('sauce:debug', {
+            method: 'Emulation.setCPUThrottlingRate',
+            params: { rate: argv.throttleCpu }
+        })
+    }
+
+    /**
+     * open page
+     */
     await browser.url(site)
 
     try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,12 +9,12 @@ import { JOB_COMPLETED_TIMEOUT, JOB_COMPLETED_INTERVAL, PERFORMANCE_METRICS, NET
  */
 const ctx = new chalk.constructor({enabled: process.env.NODE_ENV !== 'test'})
 
-const sanitizeMetric = function (metric) {
+const sanitizeMetric = function (metric, value) {
     if (metric === 'score') {
-        return Math.round(metric * 100) + '/100'
+        return Math.round(value * 100) + '/100'
     }
 
-    return prettyMs(metric)
+    return prettyMs(value)
 }
 
 /**
@@ -45,13 +45,13 @@ export const printResult = function (result, performanceLog, metrics, argv, /* i
         })
 
     for (const [metric, value] of resultsSorted) {
-        const output = `${metric}: ${sanitizeMetric(value || 0)}`
+        const output = `${metric}: ${sanitizeMetric(metric, value || 0)}`
         log(metrics.includes(metric) ? output : ctx.gray(output))
     }
 
     const resultDetails = []
     for (const [metric, { actual, lowerLimit, upperLimit }] of Object.entries(result.details)) {
-        resultDetails.push(`Expected ${metric} to be between ${sanitizeMetric(lowerLimit)} and ${sanitizeMetric(upperLimit)} but was actually ${sanitizeMetric(actual)}`)
+        resultDetails.push(`Expected ${metric} to be between ${sanitizeMetric(metric, lowerLimit)} and ${sanitizeMetric(metric, upperLimit)} but was actually ${sanitizeMetric(metric, actual)}`)
     }
 
     if (result.result === 'pass') {
@@ -183,13 +183,13 @@ export const analyzeReport = function (jobResult, metrics, /* istanbul ignore ne
             .map(({ metric, value, baseline, passed }) => {
                 return metrics.includes(metric)
                     ? `${passed
-                        ? `✅ ${ctx.bold(metric)}: ${sanitizeMetric(value)}`
-                        : `❌ ${ctx.bold(metric)}: ${sanitizeMetric(value)} ${baseline.u < value
-                            ? ctx.red(`(${sanitizeMetric(value - baseline.u)} over baseline)`)
-                            : ctx.red(`(${sanitizeMetric(baseline.l - value)} under baseline)`)
+                        ? `✅ ${ctx.bold(metric)}: ${sanitizeMetric(metric, value)}`
+                        : `❌ ${ctx.bold(metric)}: ${sanitizeMetric(metric, value)} ${baseline.u < value
+                            ? ctx.red(`(${sanitizeMetric(metric, value - baseline.u)} over baseline)`)
+                            : ctx.red(`(${sanitizeMetric(metric, baseline.l - value)} under baseline)`)
                         }`
                     }`
-                    : ctx.gray(`${metric}: ${sanitizeMetric(value)}`)
+                    : ctx.gray(`${metric}: ${sanitizeMetric(metric, value)}`)
             })
             .join('\n')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,18 +131,6 @@ export const getThrottleNetworkParam = function (argv) {
 }
 
 /**
- * validate throttleCpu param
- * @param  {Object}   argv cli params
- */
-export const getThrottleCpuParam = function (argv) {
-    const cpuRate = argv.throttleCpu || 4
-    if (typeof cpuRate !== 'number') {
-        throw new Error(`You've provided a non-numeric value for cpu throttling: ${cpuRate}`)
-    }
-    return cpuRate
-}
-
-/**
  * get job name
  * @param  {Object}   argv cli params
  */
@@ -152,8 +140,7 @@ export const getJobName = function (argv) {
     }
 
     const networkCondition = getThrottleNetworkParam(argv)
-    const cpuRate = getThrottleCpuParam(argv)
-    return `Performance test for ${argv.site} (on "${networkCondition}" and ${cpuRate}x CPU throttling)`
+    return `Performance test for ${argv.site} (on "${networkCondition}" and ${argv.throttleCpu}x CPU throttling)`
 }
 
 /**

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -95,6 +95,20 @@ Array [
 ]
 `;
 
+exports[`runPerformanceTest with no cpu throttling 1`] = `
+Array [
+  Array [
+    "sauce:debug",
+    Object {
+      "method": "Emulation.setCPUThrottlingRate",
+      "params": Object {
+        "rate": 0,
+      },
+    },
+  ],
+]
+`;
+
 exports[`runPerformanceTest without args 1`] = `
 Object {
   "result": Object {

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -95,20 +95,6 @@ Array [
 ]
 `;
 
-exports[`runPerformanceTest with no cpu throttling 1`] = `
-Array [
-  Array [
-    "sauce:debug",
-    Object {
-      "method": "Emulation.setCPUThrottlingRate",
-      "params": Object {
-        "rate": 0,
-      },
-    },
-  ],
-]
-`;
-
 exports[`runPerformanceTest without args 1`] = `
 Object {
   "result": Object {

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -27,20 +27,6 @@ test('runPerformanceTest', async () => {
     expect((await remote()).execute).toHaveBeenCalledTimes(1)
 })
 
-test('runPerformanceTest with no cpu throttling', async () => {
-    await runPerformanceTest(
-        'myuser',
-        'mykey',
-        {
-            throttleCpu: 0
-        },
-        'testname',
-        'buildname',
-        '/some/dir'
-    )
-    expect((await remote()).execute.mock.calls).toMatchSnapshot(1)
-})
-
 test('runPerformanceTest w/ parentTunnel', async () => {
     const result = await runPerformanceTest(
         'myuser',
@@ -132,4 +118,20 @@ test('runPerformanceTest throws anyway if assertPerformance continues to fail', 
         expect(remote).toBeCalledTimes(4)
         expect(e.message).toContain('boom3')
     }
+})
+
+test('runPerformanceTest should not call commands if no throttling is applied', async () => {
+    await runPerformanceTest(
+        'myuser',
+        'mykey',
+        {
+            throttleCpu: 0,
+            throttleNetwork: 'online'
+        },
+        'testname',
+        'buildname',
+        '/some/dir'
+    )
+    expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(0)
+    expect((await remote()).execute).toHaveBeenCalledTimes(0)
 })

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -27,6 +27,20 @@ test('runPerformanceTest', async () => {
     expect((await remote()).execute).toHaveBeenCalledTimes(1)
 })
 
+test('runPerformanceTest with no cpu throttling', async () => {
+    await runPerformanceTest(
+        'myuser',
+        'mykey',
+        {
+            throttleCpu: 0
+        },
+        'testname',
+        'buildname',
+        '/some/dir'
+    )
+    expect((await remote()).execute.mock.calls).toMatchSnapshot(1)
+})
+
 test('runPerformanceTest w/ parentTunnel', async () => {
     const result = await runPerformanceTest(
         'myuser',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,6 +1,6 @@
 import performanceResults from './__fixtures__/performance.json'
 import {
-    printResult, waitFor, getMetricParams, getThrottleNetworkParam, getThrottleCpuParam,
+    printResult, waitFor, getMetricParams, getThrottleNetworkParam,
     getJobUrl, analyzeReport, getJobName
 } from '../src/utils'
 import { PERFORMANCE_METRICS } from '../src/constants'
@@ -102,15 +102,6 @@ test('getThrottleNetworkParam', () => {
         .toThrow()
 })
 
-test('getThrottleCpuParam', () => {
-    expect(getThrottleCpuParam({}))
-        .toEqual(4)
-    expect(getThrottleCpuParam({ throttleCpu: 3}))
-        .toEqual(3)
-    expect(() => getThrottleCpuParam({ throttleCpu: 'invalidCpuParam' }))
-        .toThrow()
-})
-
 test('getJobUrl', () => {
     expect(getJobUrl({}, 'foobar'))
         .toEqual('https://app.saucelabs.com/performance/foobar/0')
@@ -127,6 +118,6 @@ test('analyzeReport', () => {
 })
 
 test('getJobName', () => {
-    expect(getJobName({})).toBe('Performance test for undefined (on "Good 3G" and 4x CPU throttling)')
+    expect(getJobName({ throttleCpu: 123 })).toBe('Performance test for undefined (on "Good 3G" and 123x CPU throttling)')
     expect(getJobName({ name: 'foobar' })).toBe('foobar')
 })


### PR DESCRIPTION
## Problem

When applying `0` as CPU throttle parameter it would fall back to `4`.

Fixes #45

## Solution

Force cpuThrottle parameter to be a number and fallback to 4 if not.