### PR TITLE
Allow to check for performance budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "dependencies": {
     "change-case": "^3.1.0",
+    "find-package-json": "^1.2.0",
     "ora": "^3.1.0",
     "ordinal": "^1.0.2",
     "pretty-ms": "^4.0.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,8 +50,10 @@ export const printResult = function (result, performanceLog, metrics, argv, /* i
     }
 
     const resultDetails = []
-    for (const [metric, { actual, lowerLimit, upperLimit }] of Object.entries(result.details)) {
-        resultDetails.push(`Expected ${metric} to be between ${sanitizeMetric(metric, lowerLimit)} and ${sanitizeMetric(metric, upperLimit)} but was actually ${sanitizeMetric(metric, actual)}`)
+    for (const [metric, { actual, lowerLimit, upperLimit, explicit }] of Object.entries(result.details)) {
+        resultDetails.push(explicit ?
+            `Expected ${metric} to be within performance budget of max ${sanitizeMetric(metric, upperLimit)} but was actually ${sanitizeMetric(metric, actual)}` :
+            `Expected ${metric} to be between ${sanitizeMetric(metric, lowerLimit)} and ${sanitizeMetric(metric, upperLimit)} but was actually ${sanitizeMetric(metric, actual)}`)
     }
 
     if (result.result === 'pass') {


### PR DESCRIPTION
## Problem

User sometimes want to make sure that there is a hard limit of a certain metric (e.g. total load time not over 5s).

## Solution

This patch looks into the package.json that is close to the execution directory and checks if a metric in there is defined and not under the actual metric. The performance budget can be defined as follows:

```json
  ...
  "speedo": {
    "my perf job": {
      "domContentLoaded": 767
    }
  },
  ...
```

## Comments

Some things are missing:
- add this to analyze command too
- write unit tests