### PR TITLE
Add userAgent and CPU benchmark to environment info

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
       "src/**/*.js",
       "!<rootDir>/node_modules/",
       "!<rootDir>/tests/__fixtures__/"
+    ],
+    "coveragePathIgnorePatterns": [
+      "src/scripts"
     ]
   },
   "dependencies": {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,7 +10,7 @@ import changeCase from 'change-case'
 import runPerformanceTest from '../runner'
 import {
     printResult, waitFor, getMetricParams, getJobUrl,
-    getJobName, getThrottleNetworkParam
+    getJobName, getThrottleNetworkParam, getDeviceClassFromBenchmark
 } from '../utils'
 import { ERROR_MISSING_CREDENTIALS, REQUIRED_TESTS_FOR_BASELINE_COUNT, RUN_CLI_PARAMS } from '../constants'
 
@@ -81,7 +81,7 @@ export const handler = async (argv) => {
      * run single test
      */
     status.start('Run performance test...')
-    let { result, sessionId } = await runPerformanceTest(
+    let { result, sessionId, benchmark, userAgent } = await runPerformanceTest(
         username, accessKey, argv, jobName, buildName, logDir)
 
     /**
@@ -202,9 +202,14 @@ export const handler = async (argv) => {
     printResult(result, performanceLog[0], metrics, argv)
 
     const networkCondition = getThrottleNetworkParam(argv)
-    // eslint-disable-next-line no-console
+    const runtimeSettings = [
+        `- Network Throttling: ${networkCondition}`,
+        `- CPU Throttling: ${argv.throttleCpu}x`,
+        `- CPU/Memory Power: ${benchmark} (${getDeviceClassFromBenchmark(benchmark)})`,
+        `- User Agent: ${userAgent}`
+    ]
     status.stopAndPersist({
-        text: `Runtime settings:\n- Network Throttling: ${networkCondition}\n- CPU Throttling: ${argv.throttleCpu}x\n`,
+        text: `Runtime settings:\n${runtimeSettings.join('\n')}\n`,
         symbol: '⚙️ '
     })
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,6 +1,8 @@
 import { remote } from 'webdriverio'
 
 import { getMetricParams, getThrottleNetworkParam } from './utils'
+import ultradumbBenchmarkScript from './scripts/benchmark'
+import userAgentScript from './scripts/userAgent'
 
 const MAX_RETRIES = 3
 
@@ -82,8 +84,11 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
          * any reasons, e.g. NO_NAVSTART
          */
         const result = await browser.assertPerformance(name, metrics)
+        const benchmark = await browser.execute(ultradumbBenchmarkScript)
+        const userAgent = await browser.execute(userAgentScript)
+
         await browser.deleteSession()
-        return { sessionId, result }
+        return { sessionId, result, benchmark, userAgent }
     } catch (e) {
         await browser.deleteSession()
 

--- a/src/scripts/.eslintrc
+++ b/src/scripts/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "browser": true
+  }
+}

--- a/src/scripts/benchmark.js
+++ b/src/scripts/benchmark.js
@@ -1,0 +1,26 @@
+/**
+ * Computes a memory/CPU performance benchmark index to determine rough device class.
+ * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
+ *
+ * The benchmark creates a string of length 100,000 in a loop.
+ * The returned index is the number of times per second the string can be created.
+ *
+ *  - 750+ is a desktop-class device, Core i3 PC, iPhone X, etc
+ *  - 300+ is a high-end Android phone, Galaxy S8, low-end Chromebook, etc
+ *  - 75+ is a mid-tier Android phone, Nexus 5X, etc
+ *  - <75 is a budget Android phone, Alcatel Ideal, Galaxy J2, etc
+ */
+export default function ultradumbBenchmarkScript () {
+    const start = Date.now()
+    let iterations = 0
+
+    while (Date.now() - start < 500) {
+        let s = '' // eslint-disable-line no-unused-vars
+        for (let j = 0; j < 100000; j++) s += 'a'
+
+        iterations++
+    }
+
+    const durationInSeconds = (Date.now() - start) / 1000
+    return Math.round(iterations / durationInSeconds)
+}

--- a/src/scripts/userAgent.js
+++ b/src/scripts/userAgent.js
@@ -1,0 +1,6 @@
+/**
+ * get browser user agent
+ */
+export default function userAgentScript () {
+    return navigator.userAgent
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,6 +131,21 @@ export const getThrottleNetworkParam = function (argv) {
 }
 
 /**
+ * get device class for benchmark result
+ */
+export const getDeviceClassFromBenchmark = function (benchmark) {
+    if (benchmark > 750) {
+        return 'desktop-class device'
+    } else if (benchmark > 300) {
+        return 'high-end mobile phone'
+    } else if (benchmark > 75) {
+        return 'mid-tier mobile phone'
+    }
+
+    return 'budget mobile phone'
+}
+
+/**
  * get job name
  * @param  {Object}   argv cli params
  */

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -32,6 +32,8 @@ Array [
       "text": "Runtime settings:
 - Network Throttling: undefined
 - CPU Throttling: undefinedx
+- CPU/Memory Power: 1234 (undefined)
+- User Agent: chrome
 ",
     },
   ],

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`runPerformanceTest 1`] = `
 Object {
+  "benchmark": undefined,
   "result": Object {
     "value": Object {
       "metrics": Object {
@@ -13,6 +14,7 @@ Object {
     },
   },
   "sessionId": "foobarSession",
+  "userAgent": undefined,
 }
 `;
 
@@ -49,6 +51,7 @@ Array [
 
 exports[`runPerformanceTest w/ parentTunnel 1`] = `
 Object {
+  "benchmark": undefined,
   "result": Object {
     "value": Object {
       "metrics": Object {
@@ -60,6 +63,7 @@ Object {
     },
   },
   "sessionId": "foobarSession",
+  "userAgent": undefined,
 }
 `;
 
@@ -97,6 +101,7 @@ Array [
 
 exports[`runPerformanceTest without args 1`] = `
 Object {
+  "benchmark": undefined,
   "result": Object {
     "value": Object {
       "metrics": Object {
@@ -108,6 +113,7 @@ Object {
     },
   },
   "sessionId": "foobarSession",
+  "userAgent": undefined,
 }
 `;
 

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -18,7 +18,12 @@ beforeEach(() => {
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
     getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
     waitFor.mockImplementation((condition) => condition())
-    runPerformanceTest.mockImplementation(() => ({ sessionId: 'foobar123', result: { result: 'pass' } }))
+    runPerformanceTest.mockImplementation(() => ({
+        sessionId: 'foobar123',
+        result: { result: 'pass' },
+        benchmark: 1234,
+        userAgent: 'chrome'
+    }))
 })
 
 test('run should fail if no auth is provided', async () => {
@@ -53,10 +58,20 @@ test('should rerun performance tests if they fail', async () => {
     let failures = 0
     runPerformanceTest.mockImplementation(() => {
         if (failures === 3) {
-            return { sessionId: 'foobarRetried123', result: { result: 'pass' } }
+            return {
+                sessionId: 'foobarRetried123',
+                result: { result: 'pass' },
+                benchmark: 1234,
+                userAgent: 'chrome'
+            }
         }
         ++failures
-        return { sessionId: 'foobar123', result: { result: 'failed' } }
+        return {
+            sessionId: 'foobar123',
+            result: { result: 'failed' },
+            benchmark: 1234,
+            userAgent: 'chrome'
+        }
     })
     await handler({ user: 'foo', key: 'bar', site: 'mypage', retry: 3 })
     expect(ora().text).toBe('Run performance test (3rd retry)...')
@@ -116,7 +131,9 @@ test('should run successfully', async () => {
 test('should fail build if performance test fails', async () => {
     runPerformanceTest.mockImplementation(() => ({
         sessionId: 'foobar123',
-        result: { result: 'failed' }
+        result: { result: 'failed' },
+        benchmark: 1234,
+        userAgent: 'chrome'
     }))
     await handler({ user: 'foo', key: 'bar', site: 'mypage', metric: ['load', 'speedIndex'] })
     expect(process.exit).toBeCalledWith(1)

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -24,7 +24,7 @@ test('runPerformanceTest', async () => {
     expect(remote).toBeCalledTimes(1)
     expect(remote.mock.calls).toMatchSnapshot()
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(1)
-    expect((await remote()).execute).toHaveBeenCalledTimes(1)
+    expect((await remote()).execute).toHaveBeenCalledTimes(3)
 })
 
 test('runPerformanceTest w/ parentTunnel', async () => {
@@ -46,7 +46,7 @@ test('runPerformanceTest w/ parentTunnel', async () => {
     expect(remote).toBeCalledTimes(1)
     expect(remote.mock.calls).toMatchSnapshot()
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(1)
-    expect((await remote()).execute).toHaveBeenCalledTimes(1)
+    expect((await remote()).execute).toHaveBeenCalledTimes(3)
 })
 
 test('runPerformanceTest without args', async () => {
@@ -62,7 +62,7 @@ test('runPerformanceTest without args', async () => {
     expect(remote).toBeCalledTimes(1)
     expect(remote.mock.calls).toMatchSnapshot()
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(1)
-    expect((await remote()).execute).toHaveBeenCalledTimes(1)
+    expect((await remote()).execute).toHaveBeenCalledTimes(3)
 })
 
 test('runPerformanceTest reruns if log command fails', async () => {
@@ -133,5 +133,5 @@ test('runPerformanceTest should not call commands if no throttling is applied', 
         '/some/dir'
     )
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(0)
-    expect((await remote()).execute).toHaveBeenCalledTimes(0)
+    expect((await remote()).execute).toHaveBeenCalledTimes(2)
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,7 +1,7 @@
 import performanceResults from './__fixtures__/performance.json'
 import {
     printResult, waitFor, getMetricParams, getThrottleNetworkParam,
-    getJobUrl, analyzeReport, getJobName
+    getJobUrl, analyzeReport, getJobName, getDeviceClassFromBenchmark
 } from '../src/utils'
 import { PERFORMANCE_METRICS } from '../src/constants'
 
@@ -120,4 +120,11 @@ test('analyzeReport', () => {
 test('getJobName', () => {
     expect(getJobName({ throttleCpu: 123 })).toBe('Performance test for undefined (on "Good 3G" and 123x CPU throttling)')
     expect(getJobName({ name: 'foobar' })).toBe('foobar')
+})
+
+test('getDeviceClassFromBenchmark', () => {
+    expect(getDeviceClassFromBenchmark(1000)).toBe('desktop-class device')
+    expect(getDeviceClassFromBenchmark(500)).toBe('high-end mobile phone')
+    expect(getDeviceClassFromBenchmark(150)).toBe('mid-tier mobile phone')
+    expect(getDeviceClassFromBenchmark(15)).toBe('budget mobile phone')
 })


### PR DESCRIPTION
## Problem

We want to give user more visibility into the environment the test is running in.

## Solution

Show user agent as well as some dump benchmarking in the environment:

![Screen Shot 2019-06-04 at 4 08 34 PM](https://user-images.githubusercontent.com/731337/58885739-04ef4a80-86e3-11e9-9f1a-c6cf6436b76f.png)

This data is also shown in Lighthouse audits.