### PR TITLE
Start Sauce Connect Tunnel if provided tunnelIdentifier is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM mhart/alpine-node:10.15.0
+FROM node:10.16.0
 
 WORKDIR /speedo
 ADD . /speedo
 
-RUN npm install
+RUN SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true npm install
 RUN npm run build
 
 ENV PATH $PATH:/speedo/bin

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "ora": "^3.4.0",
     "ordinal": "^1.0.3",
     "pretty-ms": "^4.0.0",
+    "sauce-connect-launcher": "^1.2.7",
     "saucelabs": "^2.1.9",
     "table": "^5.4.1",
     "tmp": "^0.1.0",

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -224,7 +224,11 @@ export const handler = async (argv) => {
     if (tunnelProcess) {
         status.start('Stopping Sauce Connect tunnel...')
         await new Promise((resolve) => {
-            const shutdownTimeout = setTimeout(resolve, TUNNEL_SHUTDOWN_TIMEOUT)
+            const shutdownTimeout = setTimeout(() => {
+                status.warn('Sauce Connect shutdown timedout, you may still have tunnels lingering around')
+                return resolve()
+            }, TUNNEL_SHUTDOWN_TIMEOUT)
+
             return tunnelProcess.close(() => {
                 clearTimeout(shutdownTimeout)
                 status.succeed()

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,7 +10,8 @@ import changeCase from 'change-case'
 import runPerformanceTest from '../runner'
 import {
     printResult, waitFor, getMetricParams, getJobUrl,
-    getJobName, getThrottleNetworkParam, getDeviceClassFromBenchmark
+    getJobName, getThrottleNetworkParam, getDeviceClassFromBenchmark,
+    startTunnel
 } from '../utils'
 import { ERROR_MISSING_CREDENTIALS, REQUIRED_TESTS_FOR_BASELINE_COUNT, RUN_CLI_PARAMS } from '../constants'
 
@@ -35,7 +36,7 @@ export const handler = async (argv) => {
         return process.exit(1)
     }
 
-    const status = ora(`Start performance test run with user ${username} on page ${argv.site}...`).start()
+    const status = ora(`Start!! performance test run with user ${username} on page ${argv.site}...`).start()
 
     const logDir = argv.logDir
         ? path.resolve(process.cwd(), argv.logDir)
@@ -64,6 +65,11 @@ export const handler = async (argv) => {
         status.fail(`Couldn't fetch job: ${e.stack}`)
         return process.exit(1)
     }
+
+    /**
+     * start Sauce Connect if not done by user
+     */
+    await startTunnel(user, argv)
 
     /**
      * create baseline if not enough tests have been executed

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -76,7 +76,7 @@ export const handler = async (argv) => {
     if (argv.tunnelIdentifier) {
         status.start(`Checking for Sauce Connect tunnel with identifier "${argv.tunnelIdentifier}"`)
         try {
-            tunnelProcess = await startTunnel(user, accessKey, logDir, argv, status)
+            tunnelProcess = await startTunnel(user, accessKey, logDir, argv.tunnelIdentifier)
 
             if (tunnelProcess) {
                 status.text = `Started Sauce Connect tunnel with identifier "${argv.tunnelIdentifier}"`

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,7 +82,7 @@ export const RUN_CLI_PARAMS ={
     browserVersion: {
         alias: 'v',
         description: 'the browser version of Chrome the performance test should run in (e.g. "74")',
-        default: '74'
+        default: 'latest'
     },
     build: {
         alias: 'b',

--- a/src/constants.js
+++ b/src/constants.js
@@ -144,3 +144,4 @@ provide them as parameter`
 export const REQUIRED_TESTS_FOR_BASELINE_COUNT = 10
 export const JOB_COMPLETED_TIMEOUT = 20000
 export const JOB_COMPLETED_INTERVAL = 1000
+export const TUNNEL_SHUTDOWN_TIMEOUT = 5000

--- a/src/runner.js
+++ b/src/runner.js
@@ -74,8 +74,15 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
 
     /**
      * open page
+     *
+     * if user is running with a Sauce Connect tunnel and tries to open
+     * a localhost page we have to modify it to be 0.0.0.0 otherwise the
+     * page won't be accessible
      */
-    await browser.url(site)
+    await browser.url(tunnelIdentifier
+        ? site.replace('localhost', '0.0.0.0')
+        : site
+    )
 
     try {
         /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -219,13 +219,23 @@ export const analyzeReport = function (jobResult, metrics, /* istanbul ignore ne
     log(table(data), `👀 Check out job at ${jobResult.url}\n`)
 }
 
-export const startTunnel = async function (user, accessKey, logDir, { tunnelIdentifier, parentTunnel }) {
+/**
+ * identifies whether a SC tunnel is already running and starts one if not
+ *
+ * @param  {Object} user             instance of API client
+ * @param  {String} accessKey        access key of user
+ * @param  {String} logDir           log directory
+ * @param  {String} tunnelIdentifier tunnel identifier to use
+ * @return {Promise|null}            null if tunnel is already running or the
+ *                                   child process object of the started tunnel
+ */
+export const startTunnel = async function (user, accessKey, logDir, tunnelIdentifier) {
     const username = user.username
     const tunnelIds = await user.listTunnels(user.username)
     const tunnels = await Promise.all(tunnelIds.map((id) => user.getTunnel(user.username, id)))
 
     const runningTunnel = tunnels.find(
-        (tunnel) => [tunnelIdentifier, parentTunnel].includes(tunnel.tunnel_identifier))
+        (tunnel) => tunnelIdentifier === tunnel.tunnel_identifier)
 
     /**
      * exit if we find tunnel

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,3 +213,14 @@ export const analyzeReport = function (jobResult, metrics, /* istanbul ignore ne
 
     log(table(data), `👀 Check out job at ${jobResult.url}\n`)
 }
+
+export const startTunnel = async function (user, { tunnelIdentifier, parentTunnel }) {
+    if (!tunnelIdentifier || parentTunnel) {
+        return process.exit(0)
+    }
+
+    const tunnelIds = await user.listTunnels(user.username)
+    const tunnels = await Promise.all(tunnelIds.map((id) => user.getTunnel(user.username, id)))
+    console.log(tunnels)
+    process.exit(0)
+}

--- a/tests/__fixtures__/tunnels.js
+++ b/tests/__fixtures__/tunnels.js
@@ -1,0 +1,37 @@
+export const TUNNELS = [
+    '02f8e61ae13f4045a4b33570560f61ef',
+    '4353456ae13sad45a4b3357056sadsad'
+]
+
+export const TUNNEL = {
+    team_ids: ['*'],
+    ssh_port: 443,
+    creation_time: 1562578702,
+    domain_names: null,
+    owner: 'cb-onboarding',
+    use_kgp: true,
+    id: '02f8e61ae13f4045a4b33570560f61ef',
+    extra_info: '{"backend": "kgp", "metrics_host": "localhost", "metrics_port": 8888}',
+    direct_domains: null,
+    vm_version: '',
+    no_ssl_bump_domains: null,
+    shared_tunnel: false,
+    metadata: { hostname: 'SL-1122',
+        git_version: '4b3da11 ',
+        platform: 'Darwin 17.7.0 Darwin Kernel Version 17.7.0: Wed Apr 24 21:17:24 PDT 2019; root:xnu-4570.71.45~1/RELEASE_X86_6 x86_64',
+        command: 'sc -u cb-onboarding -k **** -i foobar ',
+        build: 'ᇺ',
+        release: '4.5.3',
+        nofile_limit: 4864
+    },
+    status: 'running',
+    shutdown_time: null,
+    host: 'maki2169.miso.saucelabs.com',
+    ip_address: null,
+    last_connected: 1562578723,
+    user_shutdown: null,
+    use_caching_proxy: null,
+    launch_time: 1562578711,
+    no_proxy_caching: false,
+    tunnel_identifier: 'foobar'
+}

--- a/tests/__mocks__/sauce-connect-launcher.js
+++ b/tests/__mocks__/sauce-connect-launcher.js
@@ -1,0 +1,3 @@
+export default jest.fn().mockImplementation((options, cb) => {
+    setTimeout(() => cb(null, options), 100)
+})

--- a/tests/__mocks__/saucelabs.js
+++ b/tests/__mocks__/saucelabs.js
@@ -1,5 +1,6 @@
 import { PERFORMANCE_METRICS_PASSING, BASELINE_HISTORY } from '../__fixtures__/performance'
 import { TEST_WITH_BASELINE, TEST_DETAIL, JOB_ASSET } from '../__fixtures__/jobs'
+import { TUNNELS, TUNNEL } from '../__fixtures__/tunnels'
 import { BUILDS, BUILD_JOBS } from '../__fixtures__/builds.js'
 
 const defaultFixtures = {
@@ -10,6 +11,8 @@ const defaultFixtures = {
     downloadJobAsset: JOB_ASSET,
     getPerformanceMetrics: PERFORMANCE_METRICS_PASSING,
     getBaselineHistory: BASELINE_HISTORY,
+    listTunnels: TUNNELS,
+    getTunnel: TUNNEL,
     updateJob: {}
 }
 const fixtures = Object.assign({}, defaultFixtures)
@@ -21,6 +24,8 @@ const resetSauceLabsFixtures = () => {
     fixtures.downloadJobAsset = defaultFixtures.downloadJobAsset
     fixtures.getPerformanceMetrics = defaultFixtures.getPerformanceMetrics
     fixtures.getBaselineHistory = defaultFixtures.getBaselineHistory
+    fixtures.listTunnels = defaultFixtures.listTunnels
+    fixtures.getTunnel = defaultFixtures.getTunnel
     fixtures.updateJob = defaultFixtures.updateJob
 }
 
@@ -28,6 +33,7 @@ let lastInstance
 export default class SauceLabsMock {
     constructor (...args) {
         this.args = args
+        this.username = args.length ? args[0].username : undefined
         this.listJobs = jest.fn().mockImplementation(() => fixtures.listJobs)
         this.listBuilds = jest.fn().mockImplementation(() => fixtures.listBuilds)
         this.listBuildJobs = jest.fn().mockImplementation(() => fixtures.listBuildJobs)
@@ -36,6 +42,8 @@ export default class SauceLabsMock {
         this.updateJob = jest.fn().mockImplementation(() => fixtures.updateJob)
         this.getPerformanceMetrics = jest.fn().mockImplementation(() => fixtures.getPerformanceMetrics)
         this.getBaselineHistory = jest.fn().mockImplementation(() => fixtures.getBaselineHistory)
+        this.listTunnels = jest.fn().mockImplementation(() => fixtures.listTunnels)
+        this.getTunnel = jest.fn().mockImplementation(() => fixtures.getTunnel)
         lastInstance = this
     }
 }

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -46,6 +46,55 @@ Array [
 ]
 `;
 
+exports[`should run successfully with tunnels 1`] = `
+Array [
+  Array [],
+  Array [
+    "Checking for Sauce Connect tunnel with identifier \\"foobar\\"",
+  ],
+  Array [
+    "Run performance test...",
+  ],
+  Array [
+    "Wait for job to finish...",
+  ],
+  Array [
+    "Download performance logs...",
+  ],
+  Array [
+    "Updating job status...",
+  ],
+]
+`;
+
+exports[`should run successfully with tunnels 2`] = `
+Array [
+  Array [
+    Object {
+      "symbol": "📃",
+      "text": "Stored performance logs in /some/tmpDir",
+    },
+  ],
+  Array [
+    Object {
+      "symbol": "⚙️ ",
+      "text": "Runtime settings:
+- Network Throttling: undefined
+- CPU Throttling: undefinedx
+- CPU/Memory Power: 1234 (undefined)
+- User Agent: chrome
+",
+    },
+  ],
+  Array [
+    Object {
+      "symbol": "👀",
+      "text": "Check out job at https://saucelabs.com/performance/foobar/0",
+    },
+  ],
+]
+`;
+
 exports[`should store tracelogs if path provided 1`] = `
 Array [
   Array [

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -46,55 +46,6 @@ Array [
 ]
 `;
 
-exports[`should run successfully with tunnels 1`] = `
-Array [
-  Array [],
-  Array [
-    "Checking for Sauce Connect tunnel with identifier \\"foobar\\"",
-  ],
-  Array [
-    "Run performance test...",
-  ],
-  Array [
-    "Wait for job to finish...",
-  ],
-  Array [
-    "Download performance logs...",
-  ],
-  Array [
-    "Updating job status...",
-  ],
-]
-`;
-
-exports[`should run successfully with tunnels 2`] = `
-Array [
-  Array [
-    Object {
-      "symbol": "📃",
-      "text": "Stored performance logs in /some/tmpDir",
-    },
-  ],
-  Array [
-    Object {
-      "symbol": "⚙️ ",
-      "text": "Runtime settings:
-- Network Throttling: undefined
-- CPU Throttling: undefinedx
-- CPU/Memory Power: 1234 (undefined)
-- User Agent: chrome
-",
-    },
-  ],
-  Array [
-    Object {
-      "symbol": "👀",
-      "text": "Check out job at https://saucelabs.com/performance/foobar/0",
-    },
-  ],
-]
-`;
-
 exports[`should store tracelogs if path provided 1`] = `
 Array [
   Array [

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -128,7 +128,7 @@ test('should run successfully', async () => {
     expect(ora().stopAndPersist.mock.calls).toMatchSnapshot()
 })
 
-test.only('should run successfully with tunnels', async () => {
+test('should run successfully with tunnels', async () => {
     const opts = {
         user: 'foo',
         key: 'bar',
@@ -154,7 +154,7 @@ test.only('should run successfully with tunnels', async () => {
     startTunnel.mockClear()
 })
 
-test.only('should not close tunnel if none was started', async () => {
+test('should not close tunnel if none was started', async () => {
     const tunnelMock = {
         close: jest.fn().mockImplementation((cb) => setTimeout(cb, 100))
     }

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -147,8 +147,7 @@ test('should run successfully with tunnels', async () => {
         expect.any(Object),
         'bar',
         '/some/tmpDir',
-        opts,
-        expect.any(Object)
+        opts.tunnelIdentifier
     )
     expect(tunnelMock.close).toBeCalledTimes(1)
     startTunnel.mockClear()

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -154,6 +154,21 @@ test('should run successfully with tunnels', async () => {
     startTunnel.mockClear()
 })
 
+test('should fail if tunnel can not be started', async () => {
+    const opts = {
+        user: 'foo',
+        key: 'bar',
+        site: 'mypage',
+        metric: ['load', 'speedIndex'],
+        tunnelIdentifier: 'foobar'
+    }
+    startTunnel.mockReturnValue(Promise.reject(new Error('ups')))
+    await handler(opts)
+    expect(ora().fail.mock.calls.pop()[0]).toContain('Problem setting up Sauce Connect')
+    expect(process.exit).toBeCalledWith(1)
+    startTunnel.mockClear()
+})
+
 test('should not close tunnel if none was started', async () => {
     const tunnelMock = {
         close: jest.fn().mockImplementation((cb) => setTimeout(cb, 100))

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -14,7 +14,8 @@ test('runPerformanceTest', async () => {
             region: 'eu',
             platformName: 'Playstation',
             browserVersion: 123,
-            tunnelIdentifier: 'foobar'
+            tunnelIdentifier: 'foobar',
+            site: 'http://localhost:8080'
         },
         'testname',
         'buildname',
@@ -25,6 +26,7 @@ test('runPerformanceTest', async () => {
     expect(remote.mock.calls).toMatchSnapshot()
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(1)
     expect((await remote()).execute).toHaveBeenCalledTimes(3)
+    expect((await remote()).url).toBeCalledWith('http://0.0.0.0:8080')
 })
 
 test('runPerformanceTest w/ parentTunnel', async () => {
@@ -36,7 +38,8 @@ test('runPerformanceTest w/ parentTunnel', async () => {
             platformName: 'Playstation',
             browserVersion: 123,
             tunnelIdentifier: 'foobar',
-            parentTunnel: 'foobaz'
+            parentTunnel: 'foobaz',
+            site: 'https://saucelabs.com'
         },
         'testname',
         'buildname',
@@ -47,13 +50,14 @@ test('runPerformanceTest w/ parentTunnel', async () => {
     expect(remote.mock.calls).toMatchSnapshot()
     expect((await remote()).throttleNetwork).toHaveBeenCalledTimes(1)
     expect((await remote()).execute).toHaveBeenCalledTimes(3)
+    expect((await remote()).url).toBeCalledWith('https://saucelabs.com')
 })
 
 test('runPerformanceTest without args', async () => {
     const result = await runPerformanceTest(
         'myuser',
         'mykey',
-        {},
+        { site: 'https://saucelabs.com' },
         'testname',
         'buildname',
         '/some/dir'
@@ -79,7 +83,8 @@ test('runPerformanceTest reruns if log command fails', async () => {
             region: 'eu',
             platformName: 'Playstation',
             browserVersion: 123,
-            tunnelIdentifier: 'foobar'
+            tunnelIdentifier: 'foobar',
+            site: 'https://saucelabs.com'
         },
         'testname',
         'buildname',
@@ -94,7 +99,8 @@ test('runPerformanceTest throws anyway if assertPerformance continues to fail', 
 
     try {
         await runPerformanceTest(
-            // overwrite driver mock (see webdriverio mock)
+            // I know, this is not a user object but we abuse this in
+            // order overwrite driver mock (see webdriverio mock)
             {
                 assertPerformance: jest.fn()
                     .mockReturnValueOnce(Promise.reject(new Error('boom')))
@@ -108,7 +114,8 @@ test('runPerformanceTest throws anyway if assertPerformance continues to fail', 
                 region: 'eu',
                 platformName: 'Playstation',
                 browserVersion: 123,
-                tunnelIdentifier: 'foobar'
+                tunnelIdentifier: 'foobar',
+                site: 'https://saucelabs.com'
             },
             'testname',
             'buildname',
@@ -126,7 +133,8 @@ test('runPerformanceTest should not call commands if no throttling is applied', 
         'mykey',
         {
             throttleCpu: 0,
-            throttleNetwork: 'online'
+            throttleNetwork: 'online',
+            site: 'https://saucelabs.com'
         },
         'testname',
         'buildname',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -135,9 +135,7 @@ test('getDeviceClassFromBenchmark', () => {
 
 test('startTunnel should not need to start tunnel if tunnel exists', async () => {
     const user = new SauceLabs()
-    await startTunnel(user, 'accessKey', '/foo/bar', {
-        tunnelIdentifier: 'foobar'
-    })
+    await startTunnel(user, 'accessKey', '/foo/bar', 'foobar')
     expect(user.listTunnels).toBeCalledTimes(1)
     expect(user.getTunnel).toBeCalledTimes(2) // listTunnels returns 2 mocks
     expect(launchTunnel).toBeCalledTimes(0)
@@ -145,9 +143,7 @@ test('startTunnel should not need to start tunnel if tunnel exists', async () =>
 
 test('start tunnel actually starts tunnel of not existing', async () => {
     const user = new SauceLabs({ username: 'my-user' })
-    await startTunnel(user, 'accessKey', '/foo/bar', {
-        tunnelIdentifier: 'does-not-exist'
-    })
+    await startTunnel(user, 'accessKey', '/foo/bar', 'does-not-exist')
     expect(user.listTunnels).toBeCalledTimes(1)
     expect(user.getTunnel).toBeCalledTimes(2) // listTunnels returns 2 mocks
     expect(launchTunnel).toBeCalledWith({


### PR DESCRIPTION
It would be really helpful if Speedo could start the tunnel for the user in case the tunnel hasn't been started manually. For that we need to check the API if such tunnel identifier already exists and then use that or start a tunnel manually.