### PR TITLE
[Fix] remove crmuxdriverVersion:beta capability

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -11,7 +11,7 @@ import runPerformanceTest from '../runner'
 import {
     printResult, waitFor, getMetricParams, getJobUrl,
     getJobName, getThrottleNetworkParam, getDeviceClassFromBenchmark,
-    startTunnel
+    startTunnel,
 } from '../utils'
 import {
     ERROR_MISSING_CREDENTIALS, REQUIRED_TESTS_FOR_BASELINE_COUNT,
@@ -28,7 +28,7 @@ export const handler = async (argv) => {
     const jobName = getJobName(argv)
     const buildName = argv.build || `${jobName} - ${(new Date()).toString()}`
     const metrics = getMetricParams(argv)
-
+    const crmuxdriverVersion = argv.crmuxdriverVersion || 'stable'
     /**
      * check if username and access key are available
      */
@@ -97,7 +97,7 @@ export const handler = async (argv) => {
 
         const testCnt = REQUIRED_TESTS_FOR_BASELINE_COUNT - job.jobs.length
         await Promise.all([...Array(testCnt)].map(
-            () => runPerformanceTest(username, accessKey, argv, jobName, undefined, logDir)))
+            () => runPerformanceTest(username, accessKey, argv, jobName, undefined, logDir, crmuxdriverVersion)))
         status.succeed()
     }
 
@@ -106,7 +106,7 @@ export const handler = async (argv) => {
      */
     status.start('Run performance test...')
     let { result, sessionId, benchmark, userAgent } = await runPerformanceTest(
-        username, accessKey, argv, jobName, buildName, logDir)
+        username, accessKey, argv, jobName, buildName, logDir, crmuxdriverVersion)
 
     /**
      * retry performance test
@@ -118,7 +118,7 @@ export const handler = async (argv) => {
             status.text = `Run performance test (${ordinal(retry)} retry)...`
 
             const retriedResult = await runPerformanceTest(
-                username, accessKey, argv, jobName, buildName, logDir)
+                username, accessKey, argv, jobName, buildName, logDir, crmuxdriverVersion)
 
             result = retriedResult.result
             sessionId = retriedResult.sessionId

--- a/src/runner.js
+++ b/src/runner.js
@@ -17,7 +17,7 @@ const MAX_RETRIES = 3
  * @param  {String} logDir     path to directory to store logs
  * @return {Object}            containing result and detail information of performance test
  */
-export default async function runPerformanceTest(username, accessKey, argv, name, build, logDir, retryCnt = 0, crmuxdriverVersion = stable) {
+export default async function runPerformanceTest(username, accessKey, argv, name, build, logDir, retryCnt = 0, crmuxdriverVersion = 'stable') {
     const { site, platformName, browserVersion, tunnelIdentifier, parentTunnel } = argv
     const metrics = getMetricParams(argv)
     const networkCondition = getThrottleNetworkParam(argv)

--- a/src/runner.js
+++ b/src/runner.js
@@ -27,7 +27,6 @@ export default async function runPerformanceTest(username, accessKey, argv, name
             build,
             crmuxdriverVersion,
             extendedDebugging: true,
-            runPerformanceTest,
             capturePerformance: true,
             seleniumVersion: '3.141.59',
             ...(tunnelIdentifier ? { tunnelIdentifier } : {}),

--- a/src/runner.js
+++ b/src/runner.js
@@ -17,7 +17,7 @@ const MAX_RETRIES = 3
  * @param  {String} logDir     path to directory to store logs
  * @return {Object}            containing result and detail information of performance test
  */
-export default async function runPerformanceTest (username, accessKey, argv, name, build, logDir, retryCnt = 0) {
+export default async function runPerformanceTest(username, accessKey, argv, name, build, logDir, retryCnt = 0, crmuxdriverVersion = stable) {
     const { site, platformName, browserVersion, tunnelIdentifier, parentTunnel } = argv
     const metrics = getMetricParams(argv)
     const networkCondition = getThrottleNetworkParam(argv)
@@ -25,7 +25,9 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
         'sauce:options': {
             name,
             build,
+            crmuxdriverVersion,
             extendedDebugging: true,
+            runPerformanceTest,
             capturePerformance: true,
             seleniumVersion: '3.141.59',
             ...(tunnelIdentifier ? { tunnelIdentifier } : {}),

--- a/src/runner.js
+++ b/src/runner.js
@@ -27,7 +27,6 @@ export default async function runPerformanceTest (username, accessKey, argv, nam
             build,
             extendedDebugging: true,
             capturePerformance: true,
-            crmuxdriverVersion: 'beta',
             seleniumVersion: '3.141.59',
             ...(tunnelIdentifier ? { tunnelIdentifier } : {}),
             ...(parentTunnel ? { parentTunnel } : {})

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -32,7 +32,7 @@ Array [
         "sauce:options": Object {
           "build": "buildname",
           "capturePerformance": true,
-          "crmuxdriverVersion": "beta",
+          "crmuxdriverVersion": "stable",
           "extendedDebugging": true,
           "name": "testname",
           "seleniumVersion": "3.141.59",
@@ -81,7 +81,7 @@ Array [
         "sauce:options": Object {
           "build": "buildname",
           "capturePerformance": true,
-          "crmuxdriverVersion": "beta",
+          "crmuxdriverVersion": "stable",
           "extendedDebugging": true,
           "name": "testname",
           "parentTunnel": "foobaz",
@@ -131,7 +131,7 @@ Array [
         "sauce:options": Object {
           "build": "buildname",
           "capturePerformance": true,
-          "crmuxdriverVersion": "beta",
+          "crmuxdriverVersion": "stable",
           "extendedDebugging": true,
           "name": "testname",
           "seleniumVersion": "3.141.59",


### PR DESCRIPTION
 currently tests are set to run the on the beta version of performance, this may not always be intended or compatible. 
 - set default version as stable instead of beta.
- allow speedo users to pass in crmuxdriverVersion in the cli if they wish to test a different version 