### PR TITLE
Define custom network throttle capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ _default:_ `false`
 
 ##### `--throttleNetwork`
 
-Throttle network speed for your test (e.g. "Good 3G"). Available throttling profiles are: `offline`, `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `Wifi`, `online`.
+Throttle network speed for your test (e.g. "Good 3G"). Available throttling profiles are: `offline`, `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `Wifi`, `online`. You can also define your custom network profile by providing 3 with comma separated numbers for download (_kb/s_), upload (_kb/s_) and latency (_ms_), e.g. `1000,500,40`.
 
 _default:_ `"Good 3G"`
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,6 +126,15 @@ export const getMetricParams = function (argv) {
  * @param  {Object}   argv cli params
  */
 export const getThrottleNetworkParam = function (argv) {
+    /**
+     * check if custom capabilities were set
+     */
+    const throttleParams = (argv.throttleNetwork || '').match(/^(\d+),(\d+),(\d+)$/)
+    if (throttleParams) {
+        const [download, upload, latency] = throttleParams.slice(1, 4).map((val) => parseInt(val, 10))
+        return { download, upload, latency }
+    }
+
     const networkCondition = argv.throttleNetwork || 'Good 3G'
     if (!NETWORK_CONDITIONS.includes(networkCondition)) {
         throw new Error(
@@ -159,8 +168,11 @@ export const getJobName = function (argv) {
         return argv.name
     }
 
-    const networkCondition = getThrottleNetworkParam(argv)
-    return `Performance test for ${argv.site} (on "${networkCondition}" and ${argv.throttleCpu}x CPU throttling)`
+    const networkParam = getThrottleNetworkParam(argv)
+    const networkCondition = typeof networkParam === 'string'
+        ? `"${networkParam}"`
+        : 'a custom network profile'
+    return `Performance test for ${argv.site} (on ${networkCondition} and ${argv.throttleCpu}x CPU throttling)`
 }
 
 /**

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -99,11 +99,13 @@ test('getMetricParams', () => {
 
 test('getThrottleNetworkParam', () => {
     expect(getThrottleNetworkParam({}))
-        .toEqual('Good 3G')
+        .toBe('Good 3G')
     expect(getThrottleNetworkParam({ throttleNetwork: 'Regular 3G' }))
-        .toEqual('Regular 3G')
+        .toBe('Regular 3G')
     expect(() => getThrottleNetworkParam({ throttleNetwork: 'invalidNetworkCondition' }))
         .toThrow()
+    expect(getThrottleNetworkParam({ throttleNetwork: '123,456,789' }))
+        .toEqual({ download: 123, upload: 456, latency: 789 })
 })
 
 test('getJobUrl', () => {
@@ -122,7 +124,10 @@ test('analyzeReport', () => {
 })
 
 test('getJobName', () => {
-    expect(getJobName({ throttleCpu: 123 })).toBe('Performance test for undefined (on "Good 3G" and 123x CPU throttling)')
+    expect(getJobName({ throttleCpu: 123 }))
+        .toBe('Performance test for undefined (on "Good 3G" and 123x CPU throttling)')
+    expect(getJobName({ throttleCpu: 123, throttleNetwork: '111,222,333' }))
+        .toBe('Performance test for undefined (on a custom network profile and 123x CPU throttling)')
     expect(getJobName({ name: 'foobar' })).toBe('foobar')
 })
 


### PR DESCRIPTION
Currently we allow to throttle the network based on a set of predefined profiles we provide. It would be great if users can also define custom throttle capabilities in case non of the profiles fits their needs.