### PR TITLE
Allow to define a environment properties as part of a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,73 +81,101 @@ Speedo allow you to assert on the following performance metrics:
 
 #### Parameters
 
-To get the whole list of command options for the `run` command call `speedo run -h`.
+To get the whole list of command options for the `run` command call `speedo run -h`. You can either apply parameters via command line arguments or through a config file. By default Speedo looks into the directory where it is being called if a `speedo.config.js` exists. You can define different file path with the `--config` parameter.
 
-##### `--platformName` (short: `-p`)
+##### `config` (short: `-c`)
+
+Path to Speedo config file to read parameters from.
+
+_default:_ `./speedo.config.js`
+
+##### `platformName` (short: `-p`)
 
 Define the platform the performance test should run in (e.g "Windows 10").
 
 _default:_ `"Windows 10"`
 
-##### `--browserVersion` (short: `-v`)
+##### `browserVersion` (short: `-v`)
 
 Define the browser version of Chrome the performance test should run in (e.g. "latest").
 
 _default:_ `74`
 
-##### `--build` (short: `-b`)
+##### `build` (short: `-b`)
 
 Provide the name of the build you want to run your performance test in.
 
-##### `--name` (short: `-n`)
+##### `name` (short: `-n`)
 
 Define the name of your performance test.
 
 _default:_ `"Performance test for <your-site-url> (on "Good 3G" and 4x CPU throttling)"`
 
-##### `--metric` (short: `-m`)
+##### `metric` (short: `-m`)
 
 Define the metric that you want to check (multiple possible). Available performance metrics are `estimatedInputLatency`, `timeToFirstByte`, `domContentLoaded`, `firstVisualChange`, `firstPaint`, `firstContentfulPaint`, `firstMeaningfulPaint`, `lastVisualChange`, `firstCPUIdle`, `firstInteractive`, `load`, `speedIndex`, `score`.
 
 _default:_ `"score"` ([Lighthouse Performance Score](https://developers.google.com/web/tools/lighthouse/scoring))
 
-##### `--all`
+##### `all`
 
 Assert on all available metrics (ignores what is being set as `metric` parameter).
 
 _default:_ `false`
 
-##### `--throttleNetwork`
+##### `throttleNetwork`
 
 Throttle network speed for your test (e.g. "Good 3G"). Available throttling profiles are: `offline`, `GPRS`, `Regular 2G`, `Good 2G`, `Regular 3G`, `Good 3G`, `Regular 4G`, `DSL`, `Wifi`, `online`. You can also define your custom network profile by providing 3 with comma separated numbers for download (_kb/s_), upload (_kb/s_) and latency (_ms_), e.g. `1000,500,40`.
 
 _default:_ `"Good 3G"`
 
-##### `--throttleCpu`
+##### `throttleCpu`
 
 Throttle CPU speed for your test (e.g. "4" for 1/4 speed).
 
 _default:_ `4`
 
-##### `--device`
+##### `device`
 
 If set, the provided mobile device is emulated. You can choose between the following preconfigured device profiles: `Blackberry PlayBook`, `BlackBerry Z30`, `Galaxy Note 3`, `Galaxy Note II`, `Galaxy S III`, `Galaxy S5`, `iPad`, `iPad Mini`, `iPad Pro`, `iPhone 4`, `iPhone 5`, `iPhone 6`, `iPhone 6 Plus`, `iPhone 7`, `iPhone 7 Plus`, `iPhone 8`, `iPhone 8 Plus`, `iPhone SE`, `iPhone X`, `iPhone XR`, `JioPhone 2`, `Kindle Fire HDX`, `LG Optimus L70`, `Microsoft Lumia 550`, `Microsoft Lumia 950`, `Nexus 10`, `Nexus 4`, `Nexus 5`, `Nexus 5X`, `Nexus 6`, `Nexus 6P`, `Nexus 7`, `Nokia Lumia 520`, `Nokia N9`, `Pixel 2`, `Pixel 2 XL`. If you don't want to emulate a mobile device set `desktop`.
 
 _default:_ `Nexus 7`
 
-##### `--retry`
+##### `retry`
 
 Rerun failing performance tests.
 
 _default:_ `0`
 
-##### `--tunnelIdentifier` (short: `-i`)
+##### `tunnelIdentifier` (short: `-i`)
 
 Define the identifier for Sauce Connect tunnel to run performance tests for local hosted app
 
-##### `--parentTunnel`
+##### `parentTunnel`
 
 Define the username of your parent account that is running Sauce Connect tunnel.
+
+#### Run Speedo with a Config File
+
+As mentioned above Speedo looks for a `speedo.config.js` in the directory where you run the command. In this file you can define all parameters for your performance test run. Additional command line arguments will overwrite the parameters from the config, e.g.:
+
+```js
+// speedo.config.js
+module.exports = {
+    retry: 2,
+    build: `Performance Build ${CI_BUILD_NUMBER}`,
+    device: 'Nexus 7',
+    throttleCPU: 6
+}
+```
+
+If you call Speedo with:
+
+```sh
+$ speedo run https://google.org --retry 4
+```
+
+The command will retry the performance test 4 times instead of 6.
 
 ### Analyze Tests
 
@@ -200,21 +228,21 @@ The command requires passing in the job name of the performance test. With the `
 
 To get the whole list of command options for the `run` command call `speedo analyze -h`.
 
-##### `--orderIndex` (short: `-o`)
+##### `orderIndex` (short: `-o`)
 
 Define the order index of the page you have opened in that test. For example, if set to 0 you analyze the first page load, if set to 2 you want to analyze the 3rd page load.
 
-##### `--pageUrl` (short: `-p`)
+##### `pageUrl` (short: `-p`)
 
 Define the url of the page you have opened in that test (ignores `--orderIndex` parameter).
 
-##### `--metric` (short: `-m`)
+##### `metric` (short: `-m`)
 
 Define the metric that you want to check (multiple possible). Available performance metrics are `estimatedInputLatency`, `timeToFirstByte`, `domContentLoaded`, `firstVisualChange`, `firstPaint`, `firstContentfulPaint`, `firstMeaningfulPaint`, `lastVisualChange`, `firstCPUIdle`, `firstInteractive`, `load`, `speedIndex`, `score`.
 
 _default:_ `"score"` ([Lighthouse Performance Score](https://developers.google.com/web/tools/lighthouse/scoring))
 
-##### `--all`
+##### `all`
 
 Assert on all available metrics (ignores what is being set as `metric` parameter).
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -74,6 +74,11 @@ export const COMMON_CLI_PARAMS = [{
 }]
 
 export const RUN_CLI_PARAMS ={
+    config: {
+        alias: 'c',
+        description: 'path to Speedo config file to read parameters from',
+        default: './speedo.config.js'
+    },
     platformName: {
         alias: 'p',
         description: 'the platform the performance test should run in (e.g. "Windows 10")',
@@ -127,7 +132,6 @@ export const RUN_CLI_PARAMS ={
         description: 'username of parent running Sauce Connect tunnel'
     },
     crmuxdriverVersion: {
-        alias: 'c',
         default: 'stable',
         description: 'Sauce Labs internal driver version (don\'t modify this if you don\'t know what you are doing)',
         hidden: true

--- a/src/constants.js
+++ b/src/constants.js
@@ -152,6 +152,7 @@ Your Sauce credentials are missing!
 Either set 'SAUCE_USERNAME' and 'SAUCE_ACCESS_KEY' in your environment or
 provide them as parameter`
 
+export const DEFAULT_CONFIG_NAME = 'speedo.config.js'
 export const REQUIRED_TESTS_FOR_BASELINE_COUNT = 10
 export const JOB_COMPLETED_TIMEOUT = 20000
 export const JOB_COMPLETED_INTERVAL = 1000

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { table } from 'table'
@@ -5,7 +6,10 @@ import { promisify } from 'util'
 import prettyMs from 'pretty-ms'
 import launchTunnel from 'sauce-connect-launcher'
 
-import { JOB_COMPLETED_TIMEOUT, JOB_COMPLETED_INTERVAL, PERFORMANCE_METRICS, NETWORK_CONDITIONS } from './constants'
+import {
+    JOB_COMPLETED_TIMEOUT, JOB_COMPLETED_INTERVAL, PERFORMANCE_METRICS,
+    NETWORK_CONDITIONS, DEFAULT_CONFIG_NAME
+} from './constants'
 
 /**
  * disable colors in tests
@@ -266,4 +270,27 @@ export const startTunnel = async function (user, accessKey, logDir, tunnelIdenti
         logfile: path.join(logDir, SAUCE_CONNECT_LOG_FILENAME),
         tunnelIdentifier
     })
+}
+
+/**
+ * load config or read from parameters
+ * @param  {Object} argv                   parameter object
+ * @param  {Function} [requireFn=require]  require method (only for testing purposes)
+ * @return {Object}                        config object
+ */
+export const getConfig = (argv, requireFn = require) => {
+    const configFilePath = path.resolve(process.cwd(), argv.config || DEFAULT_CONFIG_NAME)
+
+    if (!fs.existsSync(configFilePath)) {
+        return argv
+    }
+
+    try {
+        const config = requireFn(configFilePath)
+        return Object.assign({}, argv, config)
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`Couldn't load config: ${e.message}`)
+        return argv
+    }
 }

--- a/tests/__fixtures__/borked.config.js
+++ b/tests/__fixtures__/borked.config.js
@@ -1,0 +1,1 @@
+throw new Error('buhh')

--- a/tests/__fixtures__/speedo.config.js
+++ b/tests/__fixtures__/speedo.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    retry: 2,
+    name: 'from config file'
+}

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -4,7 +4,7 @@ import { fixtures, lastInstance, resetSauceLabsFixtures } from 'saucelabs'
 
 import { handler } from '../src/commands/run'
 import runPerformanceTest from '../src/runner'
-import { waitFor, getMetricParams, getJobUrl, startTunnel } from '../src/utils'
+import { waitFor, getMetricParams, getJobUrl, startTunnel, getConfig } from '../src/utils'
 
 jest.mock('../src/runner')
 jest.mock('../src/utils')
@@ -19,6 +19,7 @@ beforeEach(() => {
     delete process.env.SAUCE_USERNAME
     delete process.env.SAUCE_ACCESS_KEY
 
+    getConfig.mockImplementation((argv) => argv)
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
     getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
     waitFor.mockImplementation((condition) => condition())

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import SauceLabs from 'saucelabs'
 import launchTunnel from 'sauce-connect-launcher'
 
@@ -5,7 +6,7 @@ import performanceResults from './__fixtures__/performance.json'
 import {
     printResult, waitFor, getMetricParams, getThrottleNetworkParam,
     getJobUrl, analyzeReport, getJobName, getDeviceClassFromBenchmark,
-    startTunnel
+    startTunnel, getConfig
 } from '../src/utils'
 import { PERFORMANCE_METRICS } from '../src/constants'
 
@@ -158,4 +159,27 @@ test('start tunnel actually starts tunnel of not existing', async () => {
         tunnelIdentifier: 'does-not-exist',
         username: 'my-user'
     }, expect.any(Function))
+})
+
+test('getConfig', () => {
+    const argv = {
+        build: 'barfoo',
+        name: 'foobar'
+    }
+    expect(getConfig(argv)).toEqual(argv)
+
+    const borkedConfigPath = path.resolve(__dirname, '__fixtures__', 'borked.config.js')
+    const log = ::console.error // eslint-disable-line no-console
+    console.error = jest.fn() // eslint-disable-line no-console
+    expect(getConfig({ config: borkedConfigPath }))
+        .toEqual({ config: borkedConfigPath })
+    expect(console.error).toBeCalledTimes(1) // eslint-disable-line no-console
+    console.error = log // eslint-disable-line no-console
+
+    const correctConfig = path.resolve(__dirname, '__fixtures__', 'speedo.config.js')
+    expect(getConfig({ config: correctConfig })).toEqual({
+        config: correctConfig,
+        name: 'from config file',
+        retry: 2
+    })
 })


### PR DESCRIPTION
While it is nice to modify environment capabilities for the test run, it would make it simpler to also be able to set them in a config file. Therefor I suggest to handle it similar to Jest and allow to make these configurations in the package.json or in a `speedo.config.js` file.