### PR TITLE
Populate Speedo user agent to measure usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "saucelabs": "^2.1.9",
     "table": "^5.4.1",
     "tmp": "^0.1.0",
-    "webdriverio": "^5.10.8",
+    "webdriverio": "^5.13.1",
     "yargs": "^13.2.4"
   }
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,11 +1,14 @@
 import { remote } from 'webdriverio'
+import webdriverPkg from 'webdriver/package.json'
 
 import ultradumbBenchmarkScript from './scripts/benchmark'
 import userAgentScript from './scripts/userAgent'
+import speedoPkg from '../package.json'
 import { getMetricParams, getThrottleNetworkParam } from './utils'
 import { MOBILE_DEVICES } from './constants'
 
 const MAX_RETRIES = 3
+const speedoUserAgent = `webdriver/${webdriverPkg.version} (Speedo/${speedoPkg.version})`
 
 /**
  * script that runs performance test on Sauce Labs
@@ -45,6 +48,7 @@ export default async function runPerformanceTest(username, accessKey, argv, name
         region: argv.region,
         logLevel: 'trace',
         outputDir: logDir,
+        headers: { 'User-Agent': speedoUserAgent },
         capabilities: {
             browserName: 'chrome',
             platformName,
@@ -53,6 +57,7 @@ export default async function runPerformanceTest(username, accessKey, argv, name
             ...chromeOptions
         }
     })
+
 
     const sessionId = browser.sessionId
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -58,7 +58,6 @@ export default async function runPerformanceTest(username, accessKey, argv, name
         }
     })
 
-
     const sessionId = browser.sessionId
 
     /**

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -39,6 +39,9 @@ Array [
           "tunnelIdentifier": "foobar",
         },
       },
+      "headers": Object {
+        "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
+      },
       "key": "mykey",
       "logLevel": "trace",
       "outputDir": "/some/dir",
@@ -115,6 +118,9 @@ Array [
           "tunnelIdentifier": "foobar",
         },
       },
+      "headers": Object {
+        "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
+      },
       "key": "mykey",
       "logLevel": "trace",
       "outputDir": "/some/dir",
@@ -162,6 +168,9 @@ Array [
           "name": "testname",
           "seleniumVersion": "3.141.59",
         },
+      },
+      "headers": Object {
+        "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
       },
       "key": "mykey",
       "logLevel": "trace",

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -2,6 +2,9 @@ import { remote } from 'webdriverio'
 
 import runPerformanceTest from '../src/runner'
 
+jest.mock('webdriver/package.json', () => ({ version: '5.13.1' }))
+jest.mock('../package.json', () => ({ version: '1.1.1' }))
+
 beforeEach(async () => {
     jest.clearAllMocks()
 })


### PR DESCRIPTION
It would be interesting to for usage checks if we populate the fact that someone is requesting the API with Speedo and which version is being used.