### PR TITLE
Add link to Lighthouse Report into test result std out

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -11,7 +11,7 @@ import runPerformanceTest from '../runner'
 import {
     printResult, waitFor, getMetricParams, getJobUrl,
     getJobName, getThrottleNetworkParam, getDeviceClassFromBenchmark,
-    startTunnel, getConfig
+    startTunnel, getConfig, getLigthouseReportUrl
 } from '../utils'
 import {
     ERROR_MISSING_CREDENTIALS, REQUIRED_TESTS_FOR_BASELINE_COUNT,
@@ -191,10 +191,9 @@ export const handler = async (argv) => {
     /**
      * download trace file if requested
      */
+    const loaderId = performanceLog[0].loaderId
     if (config.traceLogs) {
         status.start('Download trace logs...')
-
-        const loaderId = performanceLog[0].loaderId
         try {
             await user.downloadJobAsset(
                 sessionId,
@@ -260,6 +259,11 @@ export const handler = async (argv) => {
     status.stopAndPersist({
         text: `Check out job at ${getJobUrl(config, sessionId)}`,
         symbol: '👀'
+    })
+
+    status.stopAndPersist({
+        text: `Check out Lighthouse Report at ${getLigthouseReportUrl(config, sessionId, loaderId)}`,
+        symbol: '📔'
     })
 
     /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -191,6 +191,18 @@ export const getJobUrl = function (argv, sessionId) {
 }
 
 /**
+ * get url of Lighthouse Report
+ * @param  {Object} argv      cli params
+ * @param  {String} sessionId of test
+ * @param  {String} loaderId  id of page load
+ * @return {String}           url of lhr
+ */
+export const getLigthouseReportUrl = function (argv, sessionId, loaderId) {
+    const hostname = (!argv.region || !argv.region.includes('eu') ? 'us-west-1.' : 'eu-central-1.') + 'saucelabs.com'
+    return `https://eds.${hostname}/${sessionId}/performance/${loaderId}/lhr.html`
+}
+
+/**
  * print results of cli analyze command
  * @param  {Object}   jobResult         performance data
  * @param  {String[]} metrics           asserted metrices

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -43,6 +43,12 @@ Array [
       "text": "Check out job at https://saucelabs.com/performance/foobar/0",
     },
   ],
+  Array [
+    Object {
+      "symbol": "📔",
+      "text": "Check out Lighthouse Report at https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html",
+    },
+  ],
 ]
 `;
 

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -4,7 +4,7 @@ import { fixtures, lastInstance, resetSauceLabsFixtures } from 'saucelabs'
 
 import { handler } from '../src/commands/run'
 import runPerformanceTest from '../src/runner'
-import { waitFor, getMetricParams, getJobUrl, startTunnel, getConfig } from '../src/utils'
+import { waitFor, getMetricParams, getJobUrl, startTunnel, getConfig, getLigthouseReportUrl } from '../src/utils'
 
 jest.mock('../src/runner')
 jest.mock('../src/utils')
@@ -22,6 +22,7 @@ beforeEach(() => {
     getConfig.mockImplementation((argv) => argv)
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
     getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
+    getLigthouseReportUrl.mockImplementation(() => 'https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({
         sessionId: 'foobar123',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -6,7 +6,7 @@ import performanceResults from './__fixtures__/performance.json'
 import {
     printResult, waitFor, getMetricParams, getThrottleNetworkParam,
     getJobUrl, analyzeReport, getJobName, getDeviceClassFromBenchmark,
-    startTunnel, getConfig
+    startTunnel, getConfig, getLigthouseReportUrl
 } from '../src/utils'
 import { PERFORMANCE_METRICS } from '../src/constants'
 
@@ -116,6 +116,15 @@ test('getJobUrl', () => {
         .toEqual('https://app.eu-central-1.saucelabs.com/performance/foobar/0')
     expect(getJobUrl({ region: 'what?' }, 'foobar'))
         .toEqual('https://app.saucelabs.com/performance/foobar/0')
+})
+
+test('getLigthouseReportUrl', () => {
+    expect(getLigthouseReportUrl({}, 'foobar', 'barfoo'))
+        .toEqual('https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+    expect(getLigthouseReportUrl({ region: 'eu' }, 'foobar', 'barfoo'))
+        .toEqual('https://eds.eu-central-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+    expect(getLigthouseReportUrl({ region: 'what?' }, 'foobar', 'barfoo'))
+        .toEqual('https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
 })
 
 test('analyzeReport', () => {


### PR DESCRIPTION
## Problem

User don't have a direct way to open the Google Lighthouse Report from the command line.

## Solution

Add link to it.

## Comment

The endpoint is not yet deployed. This PR can be reviewed but should not be merged until this happened.