### PR TITLE
[PERF-1734] Use EDS through API

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -242,7 +242,7 @@ export const getJobUrl = function (argv, sessionId) {
  */
 export const getLigthouseReportUrl = function (argv, sessionId, loaderId) {
     const hostname = (!argv.region || !argv.region.includes('eu') ? 'us-west-1.' : 'eu-central-1.') + 'saucelabs.com'
-    return `https://eds.${hostname}/${sessionId}/performance/${loaderId}/lhr.html`
+    return `https://api.${hostname}/v1/eds/${sessionId}/performance/${loaderId}/lhr.html`
 }
 
 /**

--- a/tests/__snapshots__/run.test.js.snap
+++ b/tests/__snapshots__/run.test.js.snap
@@ -147,7 +147,7 @@ Array [
   Array [
     Object {
       "symbol": "📔",
-      "text": "Check out Lighthouse Report at https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html",
+      "text": "Check out Lighthouse Report at https://api.us-west-1.saucelabs.com/v1/eds/foobar/performance/barfoo/lhr.html",
     },
   ],
 ]

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -27,7 +27,7 @@ beforeEach(() => {
     getConfig.mockImplementation((argv) => argv)
     getMetricParams.mockImplementation(() => ['speedIndex', 'pageWeight'])
     getJobUrl.mockImplementation(() => 'https://saucelabs.com/performance/foobar/0')
-    getLigthouseReportUrl.mockImplementation(() => 'https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+    getLigthouseReportUrl.mockImplementation(() => 'https://api.us-west-1.saucelabs.com/v1/eds/foobar/performance/barfoo/lhr.html')
     waitFor.mockImplementation((condition) => condition())
     runPerformanceTest.mockImplementation(() => ({
         sessionId: 'foobar123',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -135,11 +135,11 @@ test('getJobUrl', () => {
 
 test('getLigthouseReportUrl', () => {
     expect(getLigthouseReportUrl({}, 'foobar', 'barfoo'))
-        .toEqual('https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+        .toEqual('https://api.us-west-1.saucelabs.com/v1/eds/foobar/performance/barfoo/lhr.html')
     expect(getLigthouseReportUrl({ region: 'eu' }, 'foobar', 'barfoo'))
-        .toEqual('https://eds.eu-central-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+        .toEqual('https://api.eu-central-1.saucelabs.com/v1/eds/foobar/performance/barfoo/lhr.html')
     expect(getLigthouseReportUrl({ region: 'what?' }, 'foobar', 'barfoo'))
-        .toEqual('https://eds.us-west-1.saucelabs.com/foobar/performance/barfoo/lhr.html')
+        .toEqual('https://api.us-west-1.saucelabs.com/v1/eds/foobar/performance/barfoo/lhr.html')
 })
 
 test('analyzeReport', () => {
@@ -211,14 +211,14 @@ test('getConfig', () => {
 test('prepareBudgetData', () => {
     const performanceBudget = {
         estimatedInputLatency: 20,
-        timeToFirstByte: [50, 100], 
+        timeToFirstByte: [50, 100],
         domContentLoaded: [200, 300],
         firstVisualChange: 100,
         firstPaint: 300,
         firstContentfulPaint: 300,
-        firstMeaningfulPaint: 300, 
-        lastVisualChange: 400, 
-        firstCPUIdle: 400,   
+        firstMeaningfulPaint: 300,
+        lastVisualChange: 400,
+        firstCPUIdle: 400,
         firstInteractive: 400,
         load: [50, 500],
         speedIndex: [100, 500],
@@ -230,14 +230,14 @@ test('prepareBudgetData', () => {
 test('getBudgetMetrics', () => {
     const performanceBudget = {
         estimatedInputLatency: 20,
-        timeToFirstByte: [50, 100], 
+        timeToFirstByte: [50, 100],
         domContentLoaded: [200, 300],
         firstVisualChange: 100,
         firstPaint: 300,
         firstContentfulPaint: 300,
-        firstMeaningfulPaint: 300, 
-        lastVisualChange: 400, 
-        firstCPUIdle: 400,   
+        firstMeaningfulPaint: 300,
+        lastVisualChange: 400,
+        firstCPUIdle: 400,
         firstInteractive: 400,
         load: [50, 500],
         speedIndex: [100, 500],


### PR DESCRIPTION
EDS service is available through `eds.*.saucelabs.com` address and through API Gateway `api.*.saucelabs.com/v1/eds`. As we want to standardize access to our services - access through API Gateway we need to start deprecating usage of eds address. 