### PR TITLE
Update wiki link with correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Speedo [![Build Status](https://travis-ci.com/saucelabs/speedo.svg?token=px5tFzamGvYgujeyYVEp&branch=master)](https://travis-ci.com/saucelabs/speedo) [![codecov](https://codecov.io/gh/saucelabs/speedo/branch/master/graph/badge.svg)](https://codecov.io/gh/saucelabs/speedo)
 ======
 
-Sauce Labs provides a [Frontend Performance Testing](https://wiki.saucelabs.com/display/DOCS/Getting+Started+with+Sauce+Performance) offering that allows you to check for crucial performance regression on your website. `Speedo` is a simple to use CLI tool that allows you to integrate this into your CI/CD pipeline. All you need to do is download and run it, just like that:
+Sauce Labs provides a [Frontend Performance Testing](https://wiki.saucelabs.com/display/DOCS/Getting+Started+with+Sauce+Front-End+Performance) offering that allows you to check for crucial performance regression on your website. `Speedo` is a simple to use CLI tool that allows you to integrate this into your CI/CD pipeline. All you need to do is download and run it, just like that:
 
 ![Speedo Test Run](./docs/speedo-run.gif "Speedo Test Run")
 


### PR DESCRIPTION
I noticed that the wiki link pointed at a page that was moved or renamed and I figured this is the right one.