### PR TITLE
Set connectionRetryTimeout

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -48,6 +48,8 @@ export default async function runPerformanceTest(
         logLevel: 'trace',
         outputDir: logDir,
         headers: { 'User-Agent': SPEEDO_WD_UA },
+        connectionRetryCount: 1,
+        connectionRetryTimeout: 180000,
         capabilities: {
             browserName: 'chrome',
             platformName,

--- a/tests/__snapshots__/runner.test.js.snap
+++ b/tests/__snapshots__/runner.test.js.snap
@@ -40,6 +40,8 @@ Array [
           "tunnelIdentifier": "foobar",
         },
       },
+      "connectionRetryCount": 1,
+      "connectionRetryTimeout": 180000,
       "headers": Object {
         "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
       },
@@ -120,6 +122,8 @@ Array [
           "tunnelIdentifier": "foobar",
         },
       },
+      "connectionRetryCount": 1,
+      "connectionRetryTimeout": 180000,
       "headers": Object {
         "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
       },
@@ -172,6 +176,8 @@ Array [
           "seleniumVersion": "3.141.59",
         },
       },
+      "connectionRetryCount": 1,
+      "connectionRetryTimeout": 180000,
       "headers": Object {
         "User-Agent": "webdriver/5.13.1 (Speedo/1.1.1)",
       },


### PR DESCRIPTION
**Problem:** webdriver retries when performance capture is in progress. This creates an issue and leads to timeout.

**Solution:** Increase retryTimeout and set retryCount: 1 to avoid any interruption in capturing performance.

This PR fixes https://github.com/saucelabs/speedo/issues/91